### PR TITLE
build: enable lto and set codegen 1 on release build

### DIFF
--- a/rustowl/Cargo.toml
+++ b/rustowl/Cargo.toml
@@ -33,3 +33,8 @@ path = "src/owlc.rs"
 [[bin]]
 name = "cargo-owlsp"
 path = "src/owlsp.rs"
+
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
Closes #4 

More information on these settings can be found here: https://nnethercote.github.io/perf-book/build-configuration.html