### PR TITLE
sccache messes with rustowl if not using nightly

### DIFF
--- a/rustowl/.cargo/config.toml
+++ b/rustowl/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustc-wrapper = ""


### PR DESCRIPTION
If you have global sccache on rustowl can possibly link against the wrong rustc? Leading to this error:
```sccache: error: failed to execute compile```

This turns off sccache when building rustowl which works for me. I don't need to disable sccache anywhere else and it works in vscode.

Thanks for the cool tool.