### PR TITLE
Kill the subprocess when the client/server is dead

### DIFF
--- a/rustowl/Cargo.lock
+++ b/rustowl/Cargo.lock
@@ -573,6 +573,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "process_alive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1b5e484e0aa9dce62b74ddce9fd0cf94b2caeac8fc53a4433a5e8202fa6c47"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,9 +610,11 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 name = "rustowl"
 version = "0.1.1"
 dependencies = [
+ "libc",
  "log",
  "mktemp",
  "models",
+ "process_alive",
  "rustowl-core",
  "serde",
  "serde_json",
@@ -959,6 +971,28 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/rustowl/Cargo.toml
+++ b/rustowl/Cargo.toml
@@ -22,6 +22,10 @@ simple_logger = { version = "5.0.0", features = ["stderr"] }
 tokio.workspace = true
 tower-lsp = "0.20.0"
 mktemp = "0.5.1"
+process_alive = "0.1.1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.169"
 
 [[bin]]
 name = "cargo-owl"


### PR DESCRIPTION
Hello, thanks for the great work.

When I was editing a (relatively large) Rust project on VSCode for MacOS with the rustowl extension enabled, I noticed that the computer would hang due to an abnormal CPU load. In the current  language server implementation, it seems that re-analyzation is performed every time the code is changed, but it did not seem to abort the previous unfinished task/command at that time (just shutting down `join` will not kill `child`), so I improved it so that it aborts them.

Also, if an editor or language server crashes for some reason, rustowlc seems to remain as an orphan process, so I changed it so that cargo owl/rustowlc is also killed when the editor or owlsp dies.

I also fixed a typo.

Please feel free to let me know if there is any issue with the modified code.

---

こんにちは。興味深くプロジェクトを拝見させていただいております。 

MacOSのVSCode上でRustOwl拡張機能を有効化したまま（比較的大きな）プロジェクトを編集していたところ、異常なCPU負荷でコンピューターがハングしてしまう事象を確認しました。現在のランゲージサーバーの実装ではコードの変更があるたびに再検査を行なっているようですが、その際に前回の未完了のタスクとコマンドをabortしていないようでしたので（`join`をshutdownしただけでは`child`はkillされません）、abortするように改良しました。

また、何らかの原因でエディタないしランゲージサーバーがクラッシュした場合rustowlcが孤立プロセスとして残留してしまうようでしたので、エディタもしくはowlspが死んだ場合cargo owl/rustowlcもまとめてkillするようにしました。 

また、typoの修正も行いました。

 変更したコードに何か問題があれば遠慮なくお申し付けください。