### PR TITLE
fix: install the newest version

### DIFF
--- a/rustowl/install.sh
+++ b/rustowl/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION="v0.1.1"
+VERSION="v0.1.2"
 
 install_rust() {
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q -y --profile minimal


### PR DESCRIPTION
The README pointing correctly to the 0.1.2 release, however the install script in there is still referencing the old version of the bin.

My suggested change might be not sufficient as it would require a re-creation of that versions release though.