### PR TITLE
chore: Migrate to Rust 2024

### DIFF
--- a/rustowl/Cargo.toml
+++ b/rustowl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustowl"
 version = "0.1.4"
-edition = "2021"
+edition = "2024"
 authors = ["cordx56 <cordx56@cordx.cx>"]
 description = "Visualize Ownership and Lifetimes in Rust"
 documentation = "https://github.com/cordx56/rustowl/blob/main/README.md"

--- a/rustowl/src/bin/cargo-owl.rs
+++ b/rustowl/src/bin/cargo-owl.rs
@@ -1,7 +1,7 @@
 use rustowl::toolchain_version;
 use std::env;
 use std::path::PathBuf;
-use std::process::{exit, Command};
+use std::process::{Command, exit};
 
 #[allow(unused)]
 use toolchain_version::TOOLCHAIN_VERSION;

--- a/rustowl/src/core/analyze.rs
+++ b/rustowl/src/core/analyze.rs
@@ -1,8 +1,8 @@
 use super::from_rustc::LocationTableSim;
 use polonius_engine::FactTypes;
 use rustc_borrowck::consumers::{
-    get_body_with_borrowck_facts, BorrowIndex, ConsumerOptions, PoloniusInput, PoloniusOutput,
-    RichLocation, RustcFacts,
+    BorrowIndex, ConsumerOptions, PoloniusInput, PoloniusOutput, RichLocation, RustcFacts,
+    get_body_with_borrowck_facts,
 };
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::{
@@ -12,7 +12,7 @@ use rustc_middle::{
     },
     ty::TyCtxt,
 };
-use rustc_span::{source_map::SourceMap, Span};
+use rustc_span::{Span, source_map::SourceMap};
 use rustowl::models::*;
 use std::collections::{BTreeSet, HashMap};
 use std::future::Future;
@@ -308,7 +308,7 @@ where
                                 target_local_index: local.as_u32(),
                                 range: range_from_span(source, statement.source_info.span, offset),
                             }),
-                            StatementKind::Assign(ref v) => {
+                            StatementKind::Assign(v) => {
                                 let (place, rval) = &**v;
                                 let target_local_index = place.local.as_u32();
                                 let rv = match rval {


### PR DESCRIPTION
`rustowl` requires `nightly-2025-02-22`, so it can be migrated to [Rust 2024](https://doc.rust-lang.org/edition-guide/rust-2024/index.html).