### PR TITLE
nvim use priorities to show the most relevant line

### DIFF
--- a/lua/rustowl.lua
+++ b/lua/rustowl.lua
@@ -10,15 +10,6 @@ vim.api.nvim_set_hl(0, 'move', { undercurl = true, sp = '#cccc00' })
 vim.api.nvim_set_hl(0, 'call', { undercurl = true, sp = '#cccc00' })
 vim.api.nvim_set_hl(0, 'outlive', { undercurl = true, sp = '#cc0000' })
 
-local hl_priorities = {
-	lifetime = 200,
-	imm_borrow = 201,
-	mut_borrow = 202,
-	move = 203,
-	call = 204,
-	outlive = 205,
-}
-
 local function show_rustowl(bufnr)
     bufnr = util.validate_bufnr(bufnr)
     local clients = util.get_lsp_clients { bufnr = bufnr, name = 'rustowl' }
@@ -36,16 +27,18 @@ local function show_rustowl(bufnr)
             function(err, result, ctx)
                 if result ~= nil then
                     for _, deco in ipairs(result['decorations']) do
-                        local start = { deco['range']['start']['line'], deco['range']['start']['character'] }
-                        local finish = { deco['range']['end']['line'], deco['range']['end']['character'] }
-                        vim.highlight.range(
-                            bufnr,
-                            hlns,
-                            deco['type'],
-                            start,
-                            finish,
-                            { regtype = "v", inclusive = true, priority = hl_priorities[deco["type"]] }
-                        )
+                        if deco['is_display'] == true then
+                            local start = { deco['range']['start']['line'], deco['range']['start']['character'] }
+                            local finish = { deco['range']['end']['line'], deco['range']['end']['character'] }
+                            vim.highlight.range(
+                                bufnr,
+                                hlns,
+                                deco['type'],
+                                start,
+                                finish,
+                                { regtype = "v", inclusive = true }
+                            )
+                        end
                     end
                 end
             end,
@@ -143,7 +136,7 @@ end
 
 return {
     rustowl_cursor = function(...)
-        args = {...}
+        args = { ... }
         bufnr = args[1] or vim.api.nvim_get_current_buf()
         show_rustowl(bufnr)
     end,

--- a/lua/rustowl.lua
+++ b/lua/rustowl.lua
@@ -10,6 +10,15 @@ vim.api.nvim_set_hl(0, 'move', { undercurl = true, sp = '#cccc00' })
 vim.api.nvim_set_hl(0, 'call', { undercurl = true, sp = '#cccc00' })
 vim.api.nvim_set_hl(0, 'outlive', { undercurl = true, sp = '#cc0000' })
 
+local hl_priorities = {
+	lifetime = 200,
+	imm_borrow = 201,
+	mut_borrow = 202,
+	move = 203,
+	call = 204,
+	outlive = 205,
+}
+
 local function show_rustowl(bufnr)
     bufnr = util.validate_bufnr(bufnr)
     local clients = util.get_lsp_clients { bufnr = bufnr, name = 'rustowl' }
@@ -35,7 +44,7 @@ local function show_rustowl(bufnr)
                             deco['type'],
                             start,
                             finish,
-                            { regtype = "v", inclusive = true }
+                            { regtype = "v", inclusive = true, priority = hl_priorities[deco["type"]] }
                         )
                     end
                 end


### PR DESCRIPTION
Always use the most relevant highlight group, i.e. if a token has both `lifetime` and `imm_borrow` highlights, use the latter, i.e. make it blue, not green.

Note:
I've tried using `vim.api.nvim_buf_set_extmark` but it didn't work properly (and even had some issue with lsp hints), but this simpler approach worked best.
I've started with priority `200` as the lowest because that's what we usually get from tresitter, but in this case any will work, only the ordering is important.