### PR TITLE
Minor Fixes for Better Emacs Lisp Compliance

### DIFF
--- a/emacs/rustowlsp.el
+++ b/emacs/rustowlsp.el
@@ -15,6 +15,12 @@
 
 ;;; Code:
 
+(defgroup rustowlsp ()
+  "Visualize Ownership and Lifetimes in Rust"
+  :group 'tools
+  :prefix "rustowlsp-"
+  :link '(url-link "https://github.com/cordx56/rustowl"))
+
 ;;;###autoload
 (with-eval-after-load 'lsp-mode
   (lsp-register-client

--- a/emacs/rustowlsp.el
+++ b/emacs/rustowlsp.el
@@ -15,6 +15,8 @@
 
 ;;; Code:
 
+(require 'lsp-mode)
+
 (defgroup rustowlsp ()
   "Visualize Ownership and Lifetimes in Rust"
   :group 'tools

--- a/emacs/rustowlsp.el
+++ b/emacs/rustowlsp.el
@@ -113,9 +113,6 @@
     (cancel-timer rustowlsp-cursor-timer)
     (setq rustowlsp-cursor-timer nil)))
 
-;;;###autoload
-(enable-rustowlsp-cursor)
-
 ;; RustOwl visualization
 (defun rustowlsp-line-col-to-pos (line col)
   (save-excursion

--- a/emacs/rustowlsp.el
+++ b/emacs/rustowlsp.el
@@ -6,7 +6,7 @@
 ;; Keywords: tools
 
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "24.1") (lsp "9.0.0"))
+;; Package-Requires: ((emacs "24.1") (lsp-mode "9.0.0"))
 ;; URL: https://github.com/cordx56/rustowl
 
 ;; SPDX-License-Identifier: MPL-2.0

--- a/emacs/rustowlsp.el
+++ b/emacs/rustowlsp.el
@@ -33,36 +33,36 @@
 
 (defun rustowlsp-cursor (params)
   (lsp-request-async
-    "rustowl/cursor"
-    params
-    (lambda (response)
-      (let ((decorations (gethash "decorations" response)))
-        (mapc
-          (lambda (deco)
-            (let* ((type (gethash "type" deco))
-                   (start (gethash "start" (gethash "range" deco)))
-                   (end (gethash "end" (gethash "range" deco)))
-                   (start-pos
-                     (line-col-to-pos
-                       (gethash "line" start)
-                       (gethash "character" start)))
-                   (end-pos
-                     (line-col-to-pos
-                       (gethash "line" end)
-                       (gethash "character" end))))
-              (cond
-                ((equal type "lifetime")
-                 (underline start-pos end-pos "#00cc00"))
-                ((equal type "imm_borrow")
-                 (underline start-pos end-pos "#0000cc"))
-                ((equal type "mut_borrow")
-                 (underline start-pos end-pos "#cc00cc"))
-                ((or (equal type "move") (equal type "call"))
-                 (underline start-pos end-pos "#cccc00"))
-                ((equal type "outlive")
-                 (underline start-pos end-pos "#cc0000")))))
-                decorations)))
-    :mode 'current))
+   "rustowl/cursor"
+   params
+   (lambda (response)
+     (let ((decorations (gethash "decorations" response)))
+       (mapc
+        (lambda (deco)
+          (let* ((type (gethash "type" deco))
+                 (start (gethash "start" (gethash "range" deco)))
+                 (end (gethash "end" (gethash "range" deco)))
+                 (start-pos
+                  (rustowlsp-line-col-to-pos
+                   (gethash "line" start)
+                   (gethash "character" start)))
+                 (end-pos
+                  (rustowlsp-line-col-to-pos
+                   (gethash "line" end)
+                   (gethash "character" end))))
+            (cond
+             ((equal type "lifetime")
+              (rustowlsp-underline start-pos end-pos "#00cc00"))
+             ((equal type "imm_borrow")
+              (rustowlsp-underline start-pos end-pos "#0000cc"))
+             ((equal type "mut_borrow")
+              (rustowlsp-underline start-pos end-pos "#cc00cc"))
+             ((or (equal type "move") (equal type "call"))
+              (rustowlsp-underline start-pos end-pos "#cccc00"))
+             ((equal type "outlive")
+              (rustowlsp-underline start-pos end-pos "#cc0000")))))
+        decorations)))
+   :mode 'current))
 
 
 (defun rustowlsp-line-number-at-pos ()
@@ -98,9 +98,9 @@
 (defun rustowlsp-reset-cursor-timer ()
   (when rustowlsp-cursor-timer
     (cancel-timer rustowlsp-cursor-timer))
-  (clear-overlays)
+  (rustowlsp-clear-overlays)
   (setq rustowlsp-cursor-timer
-    (run-with-idle-timer rustowlsp-cursor-timeout nil #'rustowlsp-cursor-call)))
+        (run-with-idle-timer rustowlsp-cursor-timeout nil #'rustowlsp-cursor-call)))
 
 ;;;###autoload
 (defun enable-rustowlsp-cursor ()
@@ -117,19 +117,22 @@
 (enable-rustowlsp-cursor)
 
 ;; RustOwl visualization
-(defun line-col-to-pos (line col)
+(defun rustowlsp-line-col-to-pos (line col)
   (save-excursion
     (goto-char (point-min))
     (forward-line line)
     (move-to-column col)
     (point)))
+
 (defvar rustowl-overlays nil)
-(defun underline (start end color)
+
+(defun rustowlsp-underline (start end color)
   (let ((overlay (make-overlay start end)))
-    (overlay-put overlay 'face `(:underline (:color ,color :style wave)))
+    (overlay-put overlay 'face `(:rustowlsp-underline (:color ,color :style wave)))
     (push overlay rustowl-overlays)
     overlay))
-(defun clear-overlays ()
+
+(defun rustowlsp-clear-overlays ()
   (interactive)
   (mapc #'delete-overlay rustowl-overlays)
   (setq rustowl-overlays nil))

--- a/emacs/rustowlsp.el
+++ b/emacs/rustowlsp.el
@@ -110,3 +110,6 @@
   (interactive)
   (mapc #'delete-overlay rustowl-overlays)
   (setq rustowl-overlays nil))
+
+(provide 'rustowlsp)
+;;; rustowlsp.el ends here

--- a/emacs/rustowlsp.el
+++ b/emacs/rustowlsp.el
@@ -1,12 +1,29 @@
+;;; rustowlsp.el --- Visualize Ownership and Lifetimes in Rust -*- lexical-binding: t; -*-
+
+;; Copyright (C) cordx56
+
+;; Author: cordx56
+;; Keywords: tools
+
+;; Version: 1.0.0
+;; Package-Requires: ((emacs "24.1"))
+;; URL: https://github.com/cordx56/rustowl
+
+;; SPDX-License-Identifier: MPL-2.0
+
+;;; Commentary:
+
+;;; Code:
+
 ;;;###autoload
 (with-eval-after-load 'lsp-mode
   (lsp-register-client
-    (make-lsp-client
-      :new-connection (lsp-stdio-connection '("cargo" "owlsp"))
-      :major-modes '(rust-mode)
-      :server-id 'rustowlsp
-      :priority -1
-      :add-on? t)))
+   (make-lsp-client
+    :new-connection (lsp-stdio-connection '("cargo" "owlsp"))
+    :major-modes '(rust-mode)
+    :server-id 'rustowlsp
+    :priority -1
+    :add-on? t)))
 
 (defun rustowlsp-cursor (params)
   (lsp-request-async

--- a/emacs/rustowlsp.el
+++ b/emacs/rustowlsp.el
@@ -6,7 +6,7 @@
 ;; Keywords: tools
 
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "24.1"))
+;; Package-Requires: ((emacs "24.1") (lsp "9.0.0"))
 ;; URL: https://github.com/cordx56/rustowl
 
 ;; SPDX-License-Identifier: MPL-2.0


### PR DESCRIPTION
I made minor fixes to the Emacs extension. The changes are as follows:
-    Added prefixes to some functions:
     -   The functions defined in the "RustOwl visualization" section have simple names like underline. However, since Emacs has a single namespace, these names may conflict with those defined in other Emacs Lisp packages.
-  Added defgroup.
-  Added (require 'lsp-mode)
   - Dependencies must be required at the beginning of the file.
-  Added a provide call:
   -  Each Emacs Lisp file should include this at the end.
-  Modified (enable-rustowlsp-cursor) to not be called within rustowlsp.el:
   -  Instead of automatically calling it when rustowlsp.el is required, it should be explicitly called in init.el.

These changes primarily follow the Emacs Lisp Coding Conventions. Additionally, there are some points that still need to be addressed:
-  rustowlsp.el completely depends on lsp-mode and does not account for other LSP clients like eglot.
   -  Issue #16 mentions eglot.
 -   Functions lack docstrings.

I appreciate your review.

---------------------------------------------------------------------------------------------------------------------
Emacs 拡張への軽微な修正を行いました。修正点は以下です:
- いくつかの関数に prefix を追加
  - "RustOwl visualization" の節で定義されている関数群は underline などシンプルな名前です。しかし，Emacs の名前空間は 1 つなので他の Emacs Lisp で定義されているとコンフリクトします。
- defgroup を追加
- (require 'lsp-mode)
  - 依存しているパッケージはファイルの先頭で require しなければいけません
- provide 呼び出しを追加
  - Emacs Lisp の各ファイルの終端にはこれが必要です。
- (enable-rustowlsp-cursor) を rustowlsp.el 内で呼び出さないように変更
  - rustowlsp.el を require しただけで呼び出されるようにするのではなく，init.el 内で呼び出すべきです

これらの修正は主に Emacs Lisp Coding Conventions に従ったものです。

また，将来的に修正したほうがいいかもしれない点もあります:  
- rustowlsp.el は lsp-mode に完全に依存しているため，eglot などの他の lsp client を考慮できていないこと
  - eglot については #16 にて言及があります。
- 関数に Docstring がないこと

レビューのほう，よろしくお願いします。