### PR TITLE
feat(neovim): `cargo owlsp` -> `rustowl`

### DIFF
--- a/lua/rustowl/config.lua
+++ b/lua/rustowl/config.lua
@@ -42,7 +42,7 @@ local default_config = {
   client = {
 
     ---@type string[]
-    cmd = { 'cargo', 'owlsp' },
+    cmd = { 'rustowl' },
 
     ---@type fun():string?
     root_dir = function()


### PR DESCRIPTION
Adapt Neovim configuration to new command name. See https://github.com/cordx56/rustowl/pull/69.