### PR TITLE
feat(toolchain): add support for RUSTOWL_TOOLCHAIN_DIR to bypass rustup

### DIFF
--- a/rustowl/build.rs
+++ b/rustowl/build.rs
@@ -7,9 +7,7 @@ fn main() {
         install_compiler();
     }
 
-    if let Ok(toolchain) = env::var("RUSTOWL_TOOLCHAIN") {
-        println!("cargo::rustc-env=RUSTOWL_TOOLCHAIN={toolchain}");
-    } else if let Some(toolchain) = get_toolchain(".") {
+    if let Some(toolchain) = get_toolchain(".") {
         println!("cargo::rustc-env=RUSTOWL_TOOLCHAIN={toolchain}");
     }
 

--- a/rustowl/build.rs
+++ b/rustowl/build.rs
@@ -7,14 +7,24 @@ fn main() {
         install_compiler();
     }
 
-    if let Some(toolchain) = get_toolchain(".") {
+    if let Ok(toolchain) = env::var("RUSTOWL_TOOLCHAIN") {
         println!("cargo::rustc-env=RUSTOWL_TOOLCHAIN={toolchain}");
+    } else if let Some(toolchain) = get_toolchain(".") {
+        println!("cargo::rustc-env=RUSTOWL_TOOLCHAIN={toolchain}");
+    }
+
+    if let Ok(toolchain_dir) = env::var("RUSTOWL_TOOLCHAIN_DIR") {
+        println!("cargo::rustc-env=RUSTOWL_TOOLCHAIN_DIR={toolchain_dir}");
     }
 }
 
 use std::path::{Path, PathBuf};
 // get toolchain
 fn get_toolchain(current: impl AsRef<Path>) -> Option<String> {
+    if let Ok(toolchain) = env::var("RUSTOWL_TOOLCHAIN") {
+        return Some(toolchain);
+    }
+
     let child = match Command::new("rustup")
         .args(["show", "active-toolchain"])
         .env_remove("RUSTUP_TOOLCHAIN")

--- a/rustowl/src/bin/rustowl.rs
+++ b/rustowl/src/bin/rustowl.rs
@@ -118,7 +118,7 @@ impl Backend {
         let roots = { self.roots.read().await.clone() };
 
         let cargo_path = rustowl::toolchain_version::TOOLCHAIN_DIR
-            .map(|dir| PathBuf::from(dir).join("bin/cargo"));
+            .map(|dir| PathBuf::from(dir).join("bin").join("cargo"));
 
         for (root, target) in roots {
             // progress report

--- a/rustowl/src/toolchain_version.rs
+++ b/rustowl/src/toolchain_version.rs
@@ -1,1 +1,2 @@
 pub const TOOLCHAIN_VERSION: &str = env!("RUSTOWL_TOOLCHAIN");
+pub const TOOLCHAIN_DIR: Option<&'static str> = option_env!("RUSTOWL_TOOLCHAIN_DIR");


### PR DESCRIPTION
- Prefer direct cargo path via RUSTOWL_TOOLCHAIN_DIR if set.

I added this because like on nix/NixOS generally don't use rustup to manage rustc, cargo, etc.. So I added some flexibility
