### PR TITLE
ci: support aarch64-unknown-linux-gnu and aarch64-pc-windows-msvc

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,34 +10,52 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - macos-15
+          - windows-2022
+          - windows-11-arm
 
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
+    defaults:
+      run:
+        working-directory: rustowl
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # We don't have rustup on the Windows 11 Arm64 runner yet, so manually installing it.
+      - if: ${{ matrix.os == 'windows-11-arm' }}
+        name: Install rustup
+        shell: bash
+        run: |
+          URL='https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe'
+          HASH="$(curl -sSL "${URL}.sha256")"
+          curl -sSL -o ./rustup-init.exe "${URL}"
+          if [ "$(sha256sum ./rustup-init.exe | cut -d' ' -f 1)" = "${HASH}" ]; then
+            ./rustup-init.exe -y --no-update-default-toolchain
+            echo "${USERPROFILE}\.cargo\bin" >> "${GITHUB_PATH}"
+          else
+            echo "::error::The SHA256 digest does not match."
+            exit 1
+          fi
+
       - name: Setup Rust
         run: rustup install
-        working-directory: rustowl
       - name: Build
         run: cargo build --release
-        working-directory: rustowl
 
       - name: Set host tuple to env
         shell: bash
         run: echo "host_tuple=$(rustc --print=host-tuple)" >> $GITHUB_ENV
-        working-directory: rustowl
       - name: Rename artifacts
         shell: bash
         run: |
           mkdir -p bin
-          for f in $(find rustowl/target/release -maxdepth 1 -perm -111 -type f); do
+          for f in $(find target/release -maxdepth 1 -perm -111 -type f); do
             BASENAME="$(basename "$f")"
             NAME="${BASENAME%%.*}";
             mv "$f" "bin/$NAME-${{ env.host_tuple }}";
@@ -47,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rustowl-bin-${{ env.host_tuple }}
-          path: bin/*
+          path: rustowl/bin/*
 
 
   vscode:


### PR DESCRIPTION
Added two platforms to the release workflow:

- aarch64-unknown-linux-gnu
- aarch64-pc-windows-msvc

Arm64 environments are now much popular, so it will be great if pre-built binaries for these platforms are provided.

Test run: https://github.com/siketyan/rustowl/actions/runs/14548266844