### PR TITLE
Fix failing build in some systems (like Nix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 /target
 
 # Nix stuff can be ignored, see https://github.com/cordx56/rustowl/issues/59
-flake.nix
-flake.lock
 result*
 .envrc
 .luarc.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,12 +324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,7 +1257,6 @@ dependencies = [
  "clap_complete",
  "clap_complete_nushell",
  "clap_mangen",
- "dunce",
  "flate2",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ clap_complete_nushell = "4.5.5"
 clap_complete = "4.5.47"
 
 [build-dependencies]
-dunce = "1.0.5"
 clap_complete_nushell = "4.5.5"
 clap_complete = "4.5.47"
 clap_mangen = "0.2.26"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,4 @@
 use clap_complete::generate_to;
-use dunce::canonicalize;
 use std::env;
 use std::fs;
 use std::io::Error;
@@ -82,7 +81,7 @@ fn recursive_read_dir(path: impl AsRef<Path>) -> Vec<PathBuf> {
         if path.is_dir() {
             paths.extend_from_slice(&recursive_read_dir(&path));
         } else {
-            paths.push(canonicalize(&path).unwrap());
+            paths.push(path);
         }
     }
     paths


### PR DESCRIPTION

```rust
fn recursive_read_dir(path: impl AsRef<Path>) -> Vec<PathBuf> {
    // ...
    paths.push(canonicalize(&path).unwrap());   // (1)
    // ...
}

fn set_rustc_driver_path(sysroot: &str) {
    // ...
    for file in recursive_read_dir(sysroot) {
        // ...
        let rel_path = file.strip_prefix(sysroot).unwrap();  // (2)
        // ...
    //...
}
```

In Nix, Rust's sysroot contents are stored in different store directories, and placed in sysroot's subdirectories using symlinks.
`canonicalize()` (in `(1)`) follows symlinks, so the prefix of the input and output of `canonicalize()` mightly differ in that case. Then the `file.strip_prefix(sysroot)` call result into `None` (in `(2)`).

This PR just remove `canonicalize()`.