### PR TITLE
fix(reqwest): dont depend on openssl-sys, use rustls for lower system deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ uuid = { version = "1", features = ["v4"] }
 clap = { version = "4.5.35", features = ["cargo"] }
 tar = "0.4.44"
 flate2 = "1.1.1"
-reqwest = "0.12.15"
+reqwest = { version = "0.12.15", features = ["rustls-tls"] }
 clap_complete_nushell = "4.5.5"
 clap_complete = "4.5.47"
 


### PR DESCRIPTION
Currently building will throw an error if openssl-sys is not found, which is needed by reqwest crate. We can bypass that with rustls-tls feature, thus no openssl-sys system dependency at build time. rustls is the rust version of openssl.

Found while creating rustowl homebrew formulae.