### PR TITLE
ci: change archive name to rustowl instead of runtime

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,9 +67,9 @@ jobs:
       - name: Set archive name
         run: |
           if [[ "${{ env.is_windows }}" == "true" ]]; then
-            echo "archive_name=runtime-${{ env.host_tuple }}.zip" >> $GITHUB_ENV
+            echo "archive_name=rustowl-${{ env.host_tuple }}.zip" >> $GITHUB_ENV
           else
-            echo "archive_name=runtime-${{ env.host_tuple }}.tar.gz" >> $GITHUB_ENV
+            echo "archive_name=rustowl-${{ env.host_tuple }}.tar.gz" >> $GITHUB_ENV
           fi
 
       - name: Setup archive artifacts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,14 @@ codegen-units = 1
 [package.metadata.rust-analyzer]
 rustc_private = true
 
+# edit on next release
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/runtime-{ target }{ archive-suffix }"
+# pkg-url = "{ repo }/releases/download/v{ version }/rustowl-{ target }{ archive-suffix }"
 disabled-strategies = ["quick-install", "compile"]
+
+# [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+# pkg-fmt = "zip"
+
+# [package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
+# pkg-fmt = "zip"

--- a/build.rs
+++ b/build.rs
@@ -22,10 +22,10 @@ fn main() -> Result<(), Error> {
     }
 
     #[cfg(not(windows))]
-    let tarball_name = format!("runtime-{}.tar.gz", get_host_tuple().unwrap());
+    let tarball_name = format!("rustowl-{}.tar.gz", get_host_tuple().unwrap());
 
     #[cfg(windows)]
-    let tarball_name = format!("runtime-{}.zip", get_host_tuple().unwrap());
+    let tarball_name = format!("rustowl-{}.zip", get_host_tuple().unwrap());
 
     println!("cargo::rustc-env=RUSTOWL_ARCHIVE_NAME={tarball_name}");
 


### PR DESCRIPTION
Currently binstall doesn't work because of https://github.com/cargo-bins/cargo-binstall/issues/1886. Thus we need to use normal packaging. Also, a archive for a package shouldn't be named runtime, it should use its own name. 