### PR TITLE
fix:78  // added a way to configure highlight style with support for under…

### DIFF
--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -4,6 +4,8 @@ if not vim.g.loaded_rustowl then
   -- Plugin initialization (run only once)
   vim.g.loaded_rustowl = true
 
+  local highlight_style = config.highlight_style or 'undercurl'
+
   local highlights = {
     lifetime = '#00cc00',
     imm_borrow = '#0000cc',
@@ -14,7 +16,14 @@ if not vim.g.loaded_rustowl then
   }
 
   for hl_name, color in pairs(highlights) do
-    local options = { undercurl = true, default = true, sp = color }
+    local options = { default = true, sp = color }
+
+    if highlight_style == 'underline' then
+      options.underline = true
+    else
+      options.undercurl = true --Default config is undercurl
+    end
+
     vim.api.nvim_set_hl(0, hl_name, options)
   end
 

--- a/lua/rustowl/config.lua
+++ b/lua/rustowl/config.lua
@@ -77,7 +77,7 @@ vim.validate {
 -- validation for highlight_style to ensure undercurl or underline
 if config.highlight_style ~= 'undercurl' and config.highlight_style ~= 'underline' then
   vim.notify(
-    "Rustown: Invalid highlight_style '" .. config.highlight_style .. "'. Using default 'undercurl'.",
+    "Rustowl: Invalid highlight_style '" .. config.highlight_style .. "'. Using default 'undercurl'.",
     vim.log.levels.WARN
   )
   config.highlight_style = 'undercurl'

--- a/lua/rustowl/config.lua
+++ b/lua/rustowl/config.lua
@@ -38,7 +38,12 @@ local default_config = {
   ---@type number
   idle_time = 500,
 
+  ---@type string
+  highlight_style = 'undercurl',
+
   ---@class rustowl.internal.ClientConfig: vim.lsp.ClientConfig
+
+  ---
   client = {
 
     ---@type string[]
@@ -66,8 +71,17 @@ vim.validate {
   auto_enable = { config.auto_enable, 'boolean' },
   idle_time = { config.idle_time, 'number' },
   client = { config.client, { 'table' } },
+  highlight_style = { config.highlight_style, 'string' },
 }
 
+-- validation for highlight_style to ensure undercurl or underline
+if config.highlight_style ~= 'undercurl' and config.highlight_style ~= 'underline' then
+  vim.notify(
+    "Rustown: Invalid highlight_style '" .. config.highlight_style .. "'. Using default 'undercurl'.",
+    vim.log.levels.WARN
+  )
+  config.highlight_style = 'undercurl'
+end
 config.client.name = 'rustowl'
 
 return config


### PR DESCRIPTION
Fix issue 78 by adding in a highlight_style variable 

With undercurl set
![Screenshot-38](https://github.com/user-attachments/assets/fcc28fa6-a4ee-452e-a112-edb65ca12c04)

With underline set 
![image](https://github.com/user-attachments/assets/f0d0792f-dd20-4d5a-8af6-8d2d763ed620)

let me know if I need to add documentation updates or anything else to this as well 