### PR TITLE
fix: dont use tar, use Compress-Archive instead

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,7 +115,7 @@ jobs:
           cd runtime
 
           if [[ "${{ env.is_windows }}" == "true" ]]; then
-            powershell -c 'tar.exe -a -cf "..\${{ env.archive_name }}" README.md LICENSE "rustowl${{ env.exec_ext }}" "rustowlc${{ env.exec_ext }}" sysroot completions man'
+            powershell -c 'Compress-Archive -Path README.md, LICENSE, "rustowl${{ env.exec_ext }}", "rustowlc${{ env.exec_ext }}", "sysroot", "completions", "man" -DestinationPath "..\${{ env.archive_name }}" -CompressionLevel Optimal'
           else
             tar -czvf ../${{ env.archive_name }} README.md LICENSE rustowl${{ env.exec_ext }} rustowlc${{ env.exec_ext }} sysroot/ completions/ man/
           fi


### PR DESCRIPTION
fixes #127 

Can't use tar, as 

- tar will compress everything to a single file, so only it can unzip, not standard zip
- Compress-Archive will use deflate algorithm with the standard zip

This might be painful but it is what it is. The reason why its not working, is the above. I tried unzipping with gnu unzip, which doesn't work. So this is the fix.