### PR TITLE
feat: add a bump.sh for bumping

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,13 +149,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
+
       - name: Install dependencies
         run: yarn install --frozen-locked
         working-directory: ./vscode
+
       - name: Create VSIX
         run: yarn build
         working-directory: ./vscode
@@ -165,7 +168,6 @@ jobs:
         with:
           name: rustowl-vscode
           path: vscode/**/*.vsix
-
 
   release:
     runs-on: ubuntu-latest
@@ -179,18 +181,25 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Download All Artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
           pattern: rustowl-*
           merge-multiple: true
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
+
       - name: Generate Release Notes
-        run: npx changelogithub@latest --output release.md
+        run: |
+          npx changelogithub@latest --contributors --output release.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Script to update version numbers in multiple files and create a git tag
+# Usage: ./bump.sh v0.3.1
+
+# Ensure a version argument is provided
+if [ $# -ne 1 ]; then
+	echo "Usage: $0 <version>"
+	echo "Example: $0 v0.3.1"
+	exit 1
+fi
+
+VERSION=$1
+VERSION_WITHOUT_V="${VERSION#v}"
+
+echo "Updating to version: $VERSION"
+
+# 1. Update Cargo.toml in root directory
+if [ -f Cargo.toml ]; then
+	echo "Updating Cargo.toml..."
+	# Use sed to replace the version line
+	sed -i "s/^version = .*/version = \"$VERSION_WITHOUT_V\"/" Cargo.toml
+else
+	echo "Error: Cargo.toml not found in current directory"
+	exit 1
+fi
+
+# 2. Update vscode/package.json
+if [ -f vscode/package.json ]; then
+	echo "Updating vscode/package.json..."
+	# Use sed to replace the "version": "x.x.x" line
+	sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION_WITHOUT_V\"/" vscode/package.json
+else
+	echo "Warning: vscode/package.json not found"
+fi
+
+# 3. Update aur/PKGBUILD
+if [ -f aur/PKGBUILD ]; then
+	echo "Updating aur/PKGBUILD..."
+	# Use sed to replace the pkgver line
+	sed -i "s/^pkgver=.*/pkgver=$VERSION_WITHOUT_V/" aur/PKGBUILD
+else
+	echo "Warning: aur/PKGBUILD not found"
+fi
+
+# 4. Create a git tag
+echo "Creating git tag: $VERSION"
+git tag $VERSION
+
+echo "Version bump complete. Changes have been made to the files."
+echo "Remember to commit your changes before pushing the tag."
+echo "To push the tag: git push origin $VERSION"

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -5,9 +5,9 @@
 
 # Ensure a version argument is provided
 if [ $# -ne 1 ]; then
-	echo "Usage: $0 <version>"
-	echo "Example: $0 v0.3.1"
-	exit 1
+  echo "Usage: $0 <version>"
+  echo "Example: $0 v0.3.1"
+  exit 1
 fi
 
 VERSION=$1
@@ -17,41 +17,41 @@ echo "Updating to version: $VERSION"
 
 # Check if version contains alpha, beta, rc, dev, or other pre-release identifiers
 if echo "$VERSION_WITHOUT_V" | grep -q -E 'alpha|beta|rc|dev|pre|snapshot'; then
-	IS_PRERELEASE=true
-	echo "Pre-release version detected ($VERSION_WITHOUT_V). PKGBUILD will not be updated."
+  IS_PRERELEASE=true
+  echo "Pre-release version detected ($VERSION_WITHOUT_V). PKGBUILD will not be updated."
 else
-	IS_PRERELEASE=false
-	echo "Stable version detected ($VERSION_WITHOUT_V)."
+  IS_PRERELEASE=false
+  echo "Stable version detected ($VERSION_WITHOUT_V)."
 fi
 
 # 1. Update Cargo.toml in root directory (only the first version field)
 if [ -f Cargo.toml ]; then
-	echo "Updating Cargo.toml..."
-	# Use sed to replace only the first occurrence of the version line
-	sed -i '0,/^version = .*/{s/^version = .*/version = "'$VERSION_WITHOUT_V'"/}' Cargo.toml
+  echo "Updating Cargo.toml..."
+  # Use sed to replace only the first occurrence of the version line
+  sed -i '0,/^version = .*/{s/^version = .*/version = "'$VERSION_WITHOUT_V'"/}' Cargo.toml
 else
-	echo "Error: Cargo.toml not found in current directory"
-	exit 1
+  echo "Error: Cargo.toml not found in current directory"
+  exit 1
 fi
 
 # 2. Update vscode/package.json
 if [ -f vscode/package.json ]; then
-	echo "Updating vscode/package.json..."
-	# Use sed to replace the "version": "x.x.x" line
-	sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION_WITHOUT_V\"/" vscode/package.json
+  echo "Updating vscode/package.json..."
+  # Use sed to replace the "version": "x.x.x" line
+  sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION_WITHOUT_V\"/" vscode/package.json
 else
-	echo "Warning: vscode/package.json not found"
+  echo "Warning: vscode/package.json not found"
 fi
 
 # 3. Update aur/PKGBUILD only for stable releases
 if [ "$IS_PRERELEASE" = false ] && [ -f aur/PKGBUILD ]; then
-	echo "Updating aur/PKGBUILD..."
-	# Use sed to replace the pkgver line
-	sed -i "s/^pkgver=.*/pkgver=$VERSION_WITHOUT_V/" aur/PKGBUILD
+  echo "Updating aur/PKGBUILD..."
+  # Use sed to replace the pkgver line
+  sed -i "s/^pkgver=.*/pkgver=$VERSION_WITHOUT_V/" aur/PKGBUILD
 elif [ -f aur/PKGBUILD ]; then
-	echo "Skipping aur/PKGBUILD update for pre-release version"
+  echo "Skipping aur/PKGBUILD update for pre-release version"
 else
-	echo "Warning: aur/PKGBUILD not found"
+  echo "Warning: aur/PKGBUILD not found"
 fi
 
 # 4. Create a git tag


### PR DESCRIPTION
How to use:

1. bump.sh: run `./scripts/bump.sh <tag alpha beta normal whatever, with the v in front, same way of git tags>`, will update aur/PKGBUILD, cargo.toml, package.json, also creates a git tag at that time.

Also, i updated release.yaml with consistent spacing, added a env GITHUB_TOKEN (forgot) at changelogithub part.