### PR TITLE
chore: Rewrite CLI using Derive API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -303,6 +304,18 @@ checksum = "c6a8b1593457dfc2fe539002b795710d022dc62a65bf15023f039f9760c7b18a"
 dependencies = [
  "clap",
  "clap_complete",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -656,6 +669,12 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tower-lsp = "0.20.0"
 process_alive = "0.1.1"
 cargo_metadata = "0.19.2"
 uuid = { version = "1", features = ["v4"] }
-clap = { version = "4.5.35", features = ["cargo"] }
+clap = { version = "4.5.35", features = ["cargo", "derive"] }
 tar = "0.4.44"
 flate2 = "1.1.1"
 reqwest = { version = "0.12.15", default-features = false, features = ["http2", "rustls-tls"] }
@@ -33,7 +33,7 @@ zip = "2.6.1"
 clap_complete_nushell = "4.5.5"
 clap_complete = "4.5.50"
 clap_mangen = "0.2.26"
-clap = { version = "4.5.35", features = ["cargo"]  }
+clap = { version = "4.5.35", features = ["derive"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.169"

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+use clap::CommandFactory;
 use clap_complete::generate_to;
 use std::env;
 use std::fs;
@@ -23,7 +24,7 @@ fn main() -> Result<(), Error> {
 
     let out_dir = Path::new(&env::var("OUT_DIR").expect("OUT_DIR unset. Expected path."))
         .join("rustowl-build-time-out");
-    let mut cmd = cli();
+    let mut cmd = Cli::command();
     let completion_out_dir = out_dir.join("completions");
     fs::create_dir_all(&completion_out_dir)?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,45 +1,53 @@
-pub fn cli() -> clap::Command {
-    clap::Command::new("RustOwl")
-        .author(clap::crate_authors!())
-        .arg(
-            clap::Arg::new("version")
-                .short('V')
-                .long("version")
-                .required(false)
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
-            clap::Arg::new("quiet")
-                .short('q')
-                .long("quiet")
-                .required(false)
-                .action(clap::ArgAction::Count),
-        )
-        .arg(
-            clap::Arg::new("io")
-                .long("stdio")
-                .required(false)
-                .action(clap::ArgAction::SetTrue),
-        )
-        .subcommand_required(false)
-        .subcommand(
-            clap::Command::new("check")
-                .arg(clap::Arg::new("path").required(false).value_name("path")),
-        )
-        .subcommand(clap::Command::new("clean"))
-        .subcommand(
-            clap::Command::new("toolchain")
-                .subcommand(clap::Command::new("install"))
-                .subcommand(clap::Command::new("uninstall")),
-        )
-        .subcommand(
-            clap::Command::new("completions")
-                .about("Generate shell completions")
-                .arg(
-                    clap::Arg::new("shell")
-                        .help("The shell to generate completions for")
-                        .required(true)
-                        .value_parser(clap::value_parser!(crate::shells::Shell)),
-                ),
-        )
+use clap::{ArgAction, Args, Parser, Subcommand, ValueHint};
+
+#[derive(Debug, Parser)]
+#[command(author)]
+pub struct Cli {
+    /// Print version.
+    #[arg(short('V'), long)]
+    pub version: bool,
+
+    #[arg(short, long, action(ArgAction::Count))]
+    pub quiet: u8,
+
+    #[arg(long)]
+    pub stdio: bool,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    Check(Check),
+    Clean,
+    Toolchain(ToolchainArgs),
+
+    /// Generate shell completions.
+    Completions(Completions),
+}
+
+#[derive(Args, Debug)]
+pub struct Check {
+    #[arg(value_name("path"), value_hint(ValueHint::AnyPath))]
+    pub path: Option<std::path::PathBuf>,
+}
+
+#[derive(Args, Debug)]
+pub struct ToolchainArgs {
+    #[command(subcommand)]
+    pub command: Option<ToolchainCommands>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ToolchainCommands {
+    Install,
+    Uninstall,
+}
+
+#[derive(Args, Debug)]
+pub struct Completions {
+    /// The shell to generate completions for.
+    #[arg(value_enum)]
+    pub shell: crate::shells::Shell,
 }

--- a/src/shells.rs
+++ b/src/shells.rs
@@ -5,14 +5,14 @@ use std::path::Path;
 use std::str::FromStr;
 
 use clap::ValueEnum;
-use clap::builder::PossibleValue;
 
 use clap_complete::Generator;
 use clap_complete::shells;
 
 /// Shell with auto-generated completion script available.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
 #[non_exhaustive]
+#[value(rename_all = "lower")]
 pub enum Shell {
     /// Bourne Again `SHell` (bash)
     Bash,
@@ -47,31 +47,6 @@ impl FromStr for Shell {
             }
         }
         Err(format!("invalid variant: {s}"))
-    }
-}
-
-// Hand-rolled so it can work even when `derive` feature is disabled
-impl ValueEnum for Shell {
-    fn value_variants<'a>() -> &'a [Self] {
-        &[
-            Shell::Bash,
-            Shell::Elvish,
-            Shell::Fish,
-            Shell::PowerShell,
-            Shell::Zsh,
-            Shell::Nushell,
-        ]
-    }
-
-    fn to_possible_value(&self) -> Option<PossibleValue> {
-        Some(match self {
-            Shell::Bash => PossibleValue::new("bash"),
-            Shell::Elvish => PossibleValue::new("elvish"),
-            Shell::Fish => PossibleValue::new("fish"),
-            Shell::PowerShell => PossibleValue::new("powershell"),
-            Shell::Zsh => PossibleValue::new("zsh"),
-            Shell::Nushell => PossibleValue::new("nushell"),
-        })
     }
 }
 


### PR DESCRIPTION
## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
None.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Change the clap API used to define CLI from the Builder API to the Derive API. This makes the CLI definition more readable and maintainable.

Added the same help message as the output of `#[command(version)]` to the help message of `--version`. The rest help message should be the same as before this change.

The behavior of CLI should be the same as before this change.