### PR TITLE
chore(man): Generate man pages for subcommands

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -52,7 +52,7 @@ package() {
     install -Dm0755 -t "$pkgdir/usr/bin/" "target/$(rustc --print=host-tuple)/release/rustowl"
     install -Dm0755 -t "$pkgdir/usr/bin/" "target/$(rustc --print=host-tuple)/release/rustowlc"
     install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/rustowl/LICENSE"
-    install -Dm644 rustowl-build-time-out/man/rustowl.1 "$pkgdir/usr/share/man/man1/rustowl.1"
+    install -Dm644 rustowl-build-time-out/man/*.1 "$pkgdir/usr/share/man/man1/"
     install -Dm644 "rustowl-build-time-out/completions/rustowl.bash" "${pkgdir}/usr/share/bash-completion/completions/rustowl"
     install -Dm644 "rustowl-build-time-out/completions/_rustowl" "${pkgdir}/usr/share/zsh/site-functions/_rustowl"
     install -Dm644 "rustowl-build-time-out/completions/rustowl.fish" "${pkgdir}/usr/share/fish/vendor_completions.d/rustowl.fish"

--- a/aur/PKGBUILD-GIT
+++ b/aur/PKGBUILD-GIT
@@ -56,7 +56,7 @@ package() {
     install -Dm0755 -t "$pkgdir/usr/bin/" "target/$(rustc --print=host-tuple)/release/rustowl"
     install -Dm0755 -t "$pkgdir/usr/bin/" "target/$(rustc --print=host-tuple)/release/rustowlc"
     install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/rustowl/LICENSE"
-    install -Dm644 rustowl-build-time-out/man/rustowl.1 "$pkgdir/usr/share/man/man1/rustowl.1"
+    install -Dm644 rustowl-build-time-out/man/*.1 "$pkgdir/usr/share/man/man1/"
     install -Dm644 "rustowl-build-time-out/completions/rustowl.bash" "${pkgdir}/usr/share/bash-completion/completions/rustowl"
     install -Dm644 "rustowl-build-time-out/completions/_rustowl" "${pkgdir}/usr/share/zsh/site-functions/_rustowl"
     install -Dm644 "rustowl-build-time-out/completions/rustowl.fish" "${pkgdir}/usr/share/fish/vendor_completions.d/rustowl.fish"

--- a/build.rs
+++ b/build.rs
@@ -31,15 +31,10 @@ fn main() -> Result<(), Error> {
     for shell in Shell::value_variants() {
         generate_to(*shell, &mut cmd, "rustowl", &completion_out_dir)?;
     }
+
     let man_out_dir = out_dir.join("man");
     fs::create_dir_all(&man_out_dir)?;
-    let man = clap_mangen::Man::new(cmd);
-    let mut buffer: Vec<u8> = Default::default();
-    man.render(&mut buffer)?;
-
-    std::fs::write(man_out_dir.join("rustowl.1"), buffer)?;
-
-    Ok(())
+    clap_mangen::generate_to(cmd, man_out_dir)
 }
 
 // get toolchain


### PR DESCRIPTION
## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
When `cargo build` is executed, generates man pages for subcommands as well.