### PR TITLE
Made all targets and all feature optionals

### DIFF
--- a/src/bin/rustowl.rs
+++ b/src/bin/rustowl.rs
@@ -27,72 +27,120 @@ fn set_log_level(default: log::LevelFilter) {
     );
 }
 
-#[tokio::main]
-async fn main() {
+/// Handles the execution of RustOwl CLI commands.
+///
+/// This function processes a specific CLI command and executes the appropriate
+/// subcommand. It handles all CLI operations including analysis checking, cache cleaning,
+/// toolchain management, and shell completion generation.
+///
+/// # Arguments
+///
+/// * `command` - The specific command to execute
+///
+/// # Returns
+///
+/// This function may exit the process with appropriate exit codes:
+/// - Exit code 0 on successful analysis
+/// - Exit code 1 on analysis failure or toolchain setup errors
+async fn handle_command(command: Commands) {
+    match command {
+        Commands::Check(command_options) => {
+            let path = command_options.path.unwrap_or(env::current_dir().unwrap());
+
+            if Backend::check_with_options(
+                &path,
+                command_options.all_targets,
+                command_options.all_features,
+            )
+            .await
+            {
+                log::info!("Successfully analyzed");
+                std::process::exit(0);
+            }
+            log::error!("Analyze failed");
+            std::process::exit(1);
+        }
+        Commands::Clean => {
+            if let Ok(meta) = cargo_metadata::MetadataCommand::new().exec() {
+                let target = meta.target_directory.join("owl");
+                tokio::fs::remove_dir_all(&target).await.ok();
+            }
+        }
+        Commands::Toolchain(command_options) => {
+            if let Some(arg) = command_options.command {
+                match arg {
+                    ToolchainCommands::Install => {
+                        if toolchain::check_fallback_dir().is_none()
+                            && rustowl::toolchain::setup_toolchain().await.is_err()
+                        {
+                            std::process::exit(1);
+                        }
+                    }
+                    ToolchainCommands::Uninstall => {
+                        rustowl::toolchain::uninstall_toolchain().await;
+                    }
+                }
+            }
+        }
+        Commands::Completions(command_options) => {
+            set_log_level("off".parse().unwrap());
+            let shell = command_options.shell;
+            generate(shell, &mut Cli::command(), "rustowl", &mut io::stdout());
+        }
+    }
+}
+
+/// Initializes the logging system with colors and default log level
+fn initialize_logging() {
     simple_logger::SimpleLogger::new()
         .with_colors(true)
         .init()
         .unwrap();
     set_log_level("info".parse().unwrap());
+}
 
-    let matches = Cli::parse();
-    if let Some(arg) = matches.command {
-        match arg {
-            Commands::Check(matches) => {
-                let path = matches.path.unwrap_or(env::current_dir().unwrap());
-                if Backend::check(&path).await {
-                    log::info!("Successfully analyzed");
-                    std::process::exit(0);
-                } else {
-                    log::error!("Analyze failed");
-                    std::process::exit(1);
-                }
-            }
-            Commands::Clean => {
-                if let Ok(meta) = cargo_metadata::MetadataCommand::new().exec() {
-                    let target = meta.target_directory.join("owl");
-                    tokio::fs::remove_dir_all(&target).await.ok();
-                }
-            }
-            Commands::Toolchain(matches) => {
-                if let Some(arg) = matches.command {
-                    match arg {
-                        ToolchainCommands::Install => {
-                            if toolchain::check_fallback_dir().is_none()
-                                && rustowl::toolchain::setup_toolchain().await.is_err()
-                            {
-                                std::process::exit(1);
-                            }
-                        }
-                        ToolchainCommands::Uninstall => {
-                            rustowl::toolchain::uninstall_toolchain().await;
-                        }
-                    }
-                }
-            }
-            Commands::Completions(matches) => {
-                set_log_level("off".parse().unwrap());
-                let shell = matches.shell;
-                generate(shell, &mut Cli::command(), "rustowl", &mut io::stdout());
-            }
-        }
-    } else if matches.version {
-        if matches.quiet == 0 {
-            print!("RustOwl ");
-        }
-        println!("v{}", clap::crate_version!());
+/// Handles the case when no command is provided (version display or LSP server mode)
+async fn handle_no_command(args: Cli) {
+    if args.version {
+        display_version(args.quiet == 0);
         return;
-    } else {
-        set_log_level("warn".parse().unwrap());
-        eprintln!("RustOwl v{}", clap::crate_version!());
-        eprintln!("This is an LSP server. You can use --help flag to show help.");
+    }
 
-        let stdin = tokio::io::stdin();
-        let stdout = tokio::io::stdout();
+    start_lsp_server().await;
+}
 
-        let (service, socket) = LspService::build(Backend::new)
-            .custom_method("rustowl/cursor", Backend::cursor)
-            .finish();
-        Server::new(stdin, stdout, socket).serve(service).await;
+/// Displays the version information
+fn display_version(show_prefix: bool) {
+    if show_prefix {
+        print!("RustOwl ");
+    }
+    println!("v{}", clap::crate_version!());
+}
+
+/// Starts the LSP server
+async fn start_lsp_server() {
+    set_log_level("warn".parse().unwrap());
+    eprintln!("RustOwl v{}", clap::crate_version!());
+    eprintln!("This is an LSP server. You can use --help flag to show help.");
+
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let (service, socket) = LspService::build(Backend::new)
+        .custom_method("rustowl/cursor", Backend::cursor)
+        .finish();
+
+    Server::new(stdin, stdout, socket).serve(service).await;
+}
+
+#[tokio::main]
+async fn main() {
+    initialize_logging();
+
+    let parsed_args = Cli::parse();
+
+    match parsed_args.command {
+        Some(command) => handle_command(command).await,
+        None => handle_no_command(parsed_args).await,
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,6 +39,26 @@ pub struct Check {
     /// The path of a file or directory to check availability.
     #[arg(value_name("path"), value_hint(ValueHint::AnyPath))]
     pub path: Option<std::path::PathBuf>,
+
+    /// Whether to check for all targets
+    /// (default: false).
+    #[arg(
+        long,
+        default_value_t = false,
+        value_name("all-targets"),
+        help = "Run the check for all targets instead of current only"
+    )]
+    pub all_targets: bool,
+
+    /// Whether to check for all features
+    /// (default: false).
+    #[arg(
+        long,
+        default_value_t = false,
+        value_name("all-features"),
+        help = "Run the check for all features instead of the current active ones only"
+    )]
+    pub all_features: bool,
 }
 
 #[derive(Args, Debug)]


### PR DESCRIPTION
## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Description
Generally, users don't need all targets and all features when working, but the active ones.
As an engineer, you want to observe the state of your active development pieces, and if rustowl check everything every time it has major cost in some cases. 
For example, in [valkey-glide](https://github.com/valkey-io/valkey-glide) it will be more than 3 time the code I need to be scanned. In this size of repo, rust owl simply crush.

Performance tests on the dummy package show a clear difference

### Performance Metrics Comparison

| Metric | Main (Improved) | All | Difference | Impact |
|--------|-----------------|-----|------------|---------|
| **Average Execution Time** | 13.13s | 18.38s | +5.25s (+40%) | All targets/features adds significant overhead |
| **Individual Run Times** | 13.20s, 13.08s, 13.14s | 18.59s, 18.31s, 18.29s | ~5.2s consistently | Very consistent overhead |
| **Binary Size** | 7.9M | 7.9M | No difference | Same binary used |
| **Symbol Count** | 11,563 | 11,563 | No difference | Same analysis scope |

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
