### PR TITLE
ci(security): don't use cache at all

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           components: miri,rust-src,llvm-tools-preview,rustc-dev
           # Automatically reads from rust-toolchain.toml
+          cache: false
       
       - name: Install system dependencies (Linux)
         if: matrix.runner_os == 'Linux'


### PR DESCRIPTION
it will take more time, but cache is making every pr workflow fail once. Meaning we need to delete cache every time. SO turn it off.