### PR TITLE
fix: call vscode bootstrap only when RustOwl is downloaded

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -6,7 +6,7 @@
   "author": "cordx56 <cordx56@cordx.cx>",
   "publisher": "cordx56",
   "engines": {
-    "vscode": "^1.100.0"
+    "vscode": "^1.101.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Call toolchain bootstrap on VSCode only when RustOwl is installed.