### PR TITLE
chore(dependabot): ignore @types/vscode version update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,5 @@ updates:
       version:
         applies-to: version-updates
         update-types: minor
+    ignore:
+      - dependency-name: "@types/vscode"


### PR DESCRIPTION
## Description

Updating `@types/vscode` version requires updating supporting VS Code engine version. So it should be done manually.