### PR TITLE
fix: visualize wrong range, caused by byte check

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -32,7 +32,7 @@ impl Loc {
         // Find the character index corresponding to the byte position
         match source_clean
             .char_indices()
-            .position(|(byte_idx, _)| (byte_pos as usize) < byte_idx)
+            .position(|(byte_idx, _)| (byte_pos as usize) <= byte_idx)
         {
             Some(char_idx) => Self(char_idx as u32),
             None => Self(source_clean.chars().count() as u32),


### PR DESCRIPTION
## Description

before:

<img width="475" alt="スクリーンショット 2025-07-08 19 34 53" src="https://github.com/user-attachments/assets/8c0a0733-ca30-4a64-b901-dd06bd7f6560" />

after:

<img width="434" alt="スクリーンショット 2025-07-08 19 40 25" src="https://github.com/user-attachments/assets/16808cbb-455a-4c5c-acb0-8e14d7d858c1" />