### PR TITLE
fix: macOS ARM compatibility with symbol resolution and library paths

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,12 @@
+[env]
+MACOSX_DEPLOYMENT_TARGET = "11.0"
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-Wl,-rpath,@loader_path",
+    "-C", "link-arg=-Wl,-rpath,@loader_path/../lib", 
+    "-C", "link-arg=-Wl,-rpath,@executable_path",
+    "-C", "link-arg=-Wl,-rpath,@executable_path/../lib",
+    "-C", "link-arg=-Wl,-rpath,/usr/local/lib",
+    "-C", "link-arg=-Wl,-rpath,/usr/lib",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,18 @@ clap_complete = "4"
 tar = "0.4.44"
 tempfile = "3"
 
+[features]
+default = []
+static-link = []
+
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 mimalloc = { version = "0.1", default-features = false, features = ['extended'] }
 libmimalloc-sys = { version = "0.1", default-features = false, features = ['extended'] }
 libc = "0.2"
+
+[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
+mimalloc = { version = "0.1", default-features = false, features = ['extended', 'secure'] }
+libmimalloc-sys = { version = "0.1", default-features = false, features = ['extended', 'secure'] }
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 mimalloc = { version = "0.1", default-features = false, features = ['extended', 'override'] }
@@ -65,6 +73,12 @@ opt-level = 3
 [profile.arm-windows-release]
 inherits = "release"
 lto = "off"
+
+[profile.arm-macos-release]
+inherits = "release"
+lto = "thin"
+codegen-units = 1
+strip = "debuginfo"
 
 [profile.security]
 inherits = "release"

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,16 @@ include!("src/shells.rs");
 
 fn main() -> Result<(), Error> {
     // Declare custom cfg flags to avoid warnings
-    println!("cargo::rustc-check-cfg=cfg(miri)");
+    println!("cargo:rustc-check-cfg=cfg(miri)");
+    println!("cargo:rustc-check-cfg=cfg(enable_static_link)");
+    println!("cargo:rustc-check-cfg=cfg(macos_arm)");
+
+    // Set up platform-specific features
+    if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        println!("cargo:rustc-cfg=macos_arm");
+        println!("cargo:rustc-cfg=enable_static_link");
+        println!("cargo:features=static-link");
+    }
 
     println!("cargo::rustc-env=RUSTOWL_TOOLCHAIN={}", get_toolchain());
     println!("cargo::rustc-env=TOOLCHAIN_CHANNEL={}", get_channel());

--- a/src/bin/rustowl.rs
+++ b/src/bin/rustowl.rs
@@ -35,7 +35,7 @@ fn setup_macos_arm_env() {
     // Set DYLD_FALLBACK_LIBRARY_PATH for macOS dynamic library loading
     if env::var_os("DYLD_FALLBACK_LIBRARY_PATH").is_none() {
         let sysroot = toolchain::get_sysroot_sync();
-        
+
         // Try to find the actual library directory containing rustc_driver
         if let Some(driver_path) = toolchain::rustc_driver_path(&sysroot) {
             if let Some(lib_dir) = driver_path.parent() {
@@ -44,21 +44,19 @@ fn setup_macos_arm_env() {
                     env::set_var("DYLD_FALLBACK_LIBRARY_PATH", &lib_path);
                 }
                 log::info!(
-                    "macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={}",
-                    lib_path
+                    "macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={lib_path}"
                 );
                 return;
             }
         }
-        
+
         // Fallback to sysroot/lib if rustc_driver not found
         let lib_path = format!("{}:/usr/local/lib:/usr/lib", sysroot.join("lib").display());
         unsafe {
             env::set_var("DYLD_FALLBACK_LIBRARY_PATH", &lib_path);
         }
         log::info!(
-            "macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={} (fallback)",
-            lib_path
+            "macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={lib_path} (fallback)"
         );
     }
 }

--- a/src/bin/rustowl.rs
+++ b/src/bin/rustowl.rs
@@ -43,9 +43,7 @@ fn setup_macos_arm_env() {
                 unsafe {
                     env::set_var("DYLD_FALLBACK_LIBRARY_PATH", &lib_path);
                 }
-                log::info!(
-                    "macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={lib_path}"
-                );
+                log::info!("macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={lib_path}");
                 return;
             }
         }
@@ -55,9 +53,7 @@ fn setup_macos_arm_env() {
         unsafe {
             env::set_var("DYLD_FALLBACK_LIBRARY_PATH", &lib_path);
         }
-        log::info!(
-            "macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={lib_path} (fallback)"
-        );
+        log::info!("macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={lib_path} (fallback)");
     }
 }
 

--- a/src/bin/rustowlc.rs
+++ b/src/bin/rustowlc.rs
@@ -51,7 +51,7 @@ fn main() {
             libmimalloc_sys::mi_realloc;
         #[used]
         static _F6: unsafe extern "C" fn(*mut c_void) = libmimalloc_sys::mi_free;
-        
+
         // Only use _mi_macros_override_malloc on non-ARM64 macOS platforms
         #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
         {
@@ -81,7 +81,7 @@ fn main() {
             // Set DYLD_FALLBACK_LIBRARY_PATH for macOS if not already set
             if std::env::var_os("DYLD_FALLBACK_LIBRARY_PATH").is_none() {
                 let sysroot = rustowl::toolchain::get_sysroot_sync();
-                
+
                 // Find the actual library directory containing rustc_driver
                 if let Some(driver_path) = rustowl::toolchain::rustc_driver_path(&sysroot) {
                     if let Some(lib_dir) = driver_path.parent() {
@@ -90,8 +90,7 @@ fn main() {
                             std::env::set_var("DYLD_FALLBACK_LIBRARY_PATH", &lib_path);
                         }
                         eprintln!(
-                            "macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={}",
-                            lib_path
+                            "macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={lib_path}"
                         );
                     }
                 } else {
@@ -101,8 +100,7 @@ fn main() {
                         std::env::set_var("DYLD_FALLBACK_LIBRARY_PATH", &lib_path);
                     }
                     eprintln!(
-                        "macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={} (fallback)",
-                        lib_path
+                        "macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={lib_path} (fallback)"
                     );
                 }
             }

--- a/src/bin/rustowlc.rs
+++ b/src/bin/rustowlc.rs
@@ -89,9 +89,7 @@ fn main() {
                         unsafe {
                             std::env::set_var("DYLD_FALLBACK_LIBRARY_PATH", &lib_path);
                         }
-                        eprintln!(
-                            "macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={lib_path}"
-                        );
+                        eprintln!("macOS ARM detected: Set DYLD_FALLBACK_LIBRARY_PATH={lib_path}");
                     }
                 } else {
                     // Fallback to sysroot/lib if rustc_driver not found

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -36,7 +36,7 @@ pub fn get_sysroot_sync() -> PathBuf {
             if is_valid_sysroot(&sysroot) {
                 log::info!(
                     "select sysroot dir from rustup installed: {}",
-                    sysroot.display(),
+                    sysroot.display()
                 );
                 return sysroot;
             }
@@ -174,7 +174,7 @@ fn get_configured_sysroot() -> Option<PathBuf> {
         if is_valid_sysroot(sysroot) {
             log::info!(
                 "select sysroot dir from build time env var: {}",
-                sysroot.display(),
+                sysroot.display()
             );
             return Some(sysroot.clone());
         }
@@ -200,7 +200,7 @@ pub async fn get_sysroot() -> PathBuf {
     {
         log::info!(
             "select sysroot dir from rustup installed: {}",
-            sysroot.display(),
+            sysroot.display()
         );
         return sysroot;
     }


### PR DESCRIPTION
- Added static-link feature for memory allocator
- Created specific build profile for macOS ARM
- Added ARM-specific memory allocator settings
- Set up DYLD_FALLBACK_LIBRARY_PATH for macOS ARM
- Added synchronous wrapper for get_sysroot

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
