### PR TITLE
fix: add skip installing RustOwl toolchain option

### DIFF
--- a/src/bin/rustowl.rs
+++ b/src/bin/rustowl.rs
@@ -70,9 +70,15 @@ async fn handle_command(command: Commands) {
         Commands::Toolchain(command_options) => {
             if let Some(arg) = command_options.command {
                 match arg {
-                    ToolchainCommands::Install { path } => {
+                    ToolchainCommands::Install {
+                        path,
+                        skip_rustowl_toolchain,
+                    } => {
                         let path = path.unwrap_or(toolchain::FALLBACK_RUNTIME_DIR.clone());
-                        if toolchain::setup_toolchain(&path).await.is_err() {
+                        if toolchain::setup_toolchain(&path, skip_rustowl_toolchain)
+                            .await
+                            .is_err()
+                        {
                             std::process::exit(1);
                         }
                     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,9 +75,15 @@ pub enum ToolchainCommands {
             long,
             value_name("path"),
             value_hint(ValueHint::AnyPath),
-            help = "Path to install RustOwl toolchain"
+            help = "Runtime directory path to install RustOwl toolchain"
         )]
         path: Option<std::path::PathBuf>,
+        #[arg(
+            long,
+            value_name("skip-rustowl-toolchain"),
+            help = "Install Rust toolchain only"
+        )]
+        skip_rustowl_toolchain: bool,
     },
 
     /// Uninstall the toolchain.


### PR DESCRIPTION
related: #286 

## Description

add skip installing RustOwl toolchain option on `rustowl toolchain install`.
This is useful on building RustOwl.