### PR TITLE
feat(cache): Implement cache mechanism

### DIFF
--- a/src/bin/core/analyze.rs
+++ b/src/bin/core/analyze.rs
@@ -1,3 +1,4 @@
+use super::cache;
 use polonius_engine::FactTypes;
 use rustc_borrowck::consumers::{
     BorrowSet, ConsumerOptions, PoloniusInput, PoloniusLocationTable, PoloniusOutput, RichLocation,
@@ -17,9 +18,23 @@ use std::collections::{BTreeSet, HashMap};
 use std::future::Future;
 use std::hash::Hash;
 use std::pin::Pin;
+use std::sync::LazyLock;
 
 pub type MirAnalyzeFuture<'tcx> =
     Pin<Box<dyn Future<Output = MirAnalyzer<'tcx>> + Send + Sync + 'tcx>>;
+
+#[derive(Clone, Debug)]
+pub struct AnalyzeResult {
+    pub file_name: String,
+    pub file_hash: String,
+    pub mir_hash: String,
+    pub analyzed: Function,
+}
+
+pub enum MirAnalyzerInitResult<'tcx> {
+    Cached(AnalyzeResult),
+    Analyzer(MirAnalyzeFuture<'tcx>),
+}
 
 type Borrow = <RustcFacts as FactTypes>::Loan;
 type Region = <RustcFacts as FactTypes>::Origin;
@@ -58,6 +73,8 @@ where
     }
 }
 
+static CACHE: LazyLock<Option<cache::CacheData>> = LazyLock::new(|| cache::get_incremental_cache());
+
 fn range_from_span(source: &str, span: Span, offset: u32) -> Option<Range> {
     let from = Loc::new(source, span.lo().0, offset);
     let until = Loc::new(source, span.hi().0, offset);
@@ -65,7 +82,7 @@ fn range_from_span(source: &str, span: Span, offset: u32) -> Option<Range> {
 }
 
 pub struct MirAnalyzer<'tcx> {
-    filename: String,
+    file_name: String,
     source: String,
     offset: u32,
     location_table: PoloniusLocationTable,
@@ -78,10 +95,12 @@ pub struct MirAnalyzer<'tcx> {
     borrow_locals: HashMap<Borrow, Local>,
     basic_blocks: Vec<MirBasicBlock>,
     fn_id: LocalDefId,
+    file_hash: String,
+    mir_hash: String,
 }
 impl MirAnalyzer<'_> {
     /// initialize analyzer
-    pub fn new(tcx: TyCtxt<'_>, fn_id: LocalDefId) -> MirAnalyzeFuture<'_> {
+    pub fn new(tcx: TyCtxt<'_>, fn_id: LocalDefId) -> MirAnalyzerInitResult<'_> {
         let mut facts =
             get_body_with_borrowck_facts(tcx, fn_id, ConsumerOptions::PoloniusOutputFacts);
         let input = *facts.input_facts.take().unwrap();
@@ -91,17 +110,31 @@ impl MirAnalyzer<'_> {
 
         let source_map = tcx.sess.source_map();
 
-        let filename = source_map.span_to_filename(facts.body.span);
-        let source_file = source_map.get_source_file(&filename).unwrap();
+        let file_name = source_map.span_to_filename(facts.body.span);
+        let source_file = source_map.get_source_file(&file_name).unwrap();
         let offset = source_file.start_pos.0;
-        let filename = source_map.path_mapping().to_embeddable_absolute_path(
-            rustc_span::RealFileName::LocalPath(filename.into_local_path().unwrap()),
+        let file_name = source_map.path_mapping().to_embeddable_absolute_path(
+            rustc_span::RealFileName::LocalPath(file_name.into_local_path().unwrap()),
             &rustc_span::RealFileName::LocalPath(std::env::current_dir().unwrap()),
         );
-        let path = filename.to_path(rustc_span::FileNameDisplayPreference::Local);
+        let path = file_name.to_path(rustc_span::FileNameDisplayPreference::Local);
         let source = std::fs::read_to_string(path).unwrap();
-        let filename = path.to_string_lossy().to_string();
+        let file_name = path.to_string_lossy().to_string();
         log::info!("facts of {fn_id:?} prepared; start analyze of {fn_id:?}");
+
+        let mir_hash = cache::Hasher::get_hash(tcx, &body);
+        let file_hash = cache::Hasher::get_hash(tcx, &source);
+        if let Some(cache) = &*CACHE {
+            if let Some(analyzed) = cache.get_cache(&file_hash, &mir_hash) {
+                log::info!("MIR cache hit: {fn_id:?}");
+                return MirAnalyzerInitResult::Cached(AnalyzeResult {
+                    file_name,
+                    file_hash,
+                    mir_hash,
+                    analyzed: analyzed.clone(),
+                });
+            }
+        }
 
         // local -> all borrows on that local
         let mut borrow_locals = HashMap::new();
@@ -126,7 +159,7 @@ impl MirAnalyzer<'_> {
             tcx.sess.source_map(),
         );
 
-        Box::pin(async move {
+        let analyzer = Box::pin(async move {
             log::info!("start re-computing borrow check with dump: true");
             // compute insensitive
             // it may include invalid region, which can be used at showing wrong region
@@ -141,7 +174,7 @@ impl MirAnalyzer<'_> {
             log::info!("borrow check finished");
 
             MirAnalyzer {
-                filename,
+                file_name,
                 source,
                 offset,
                 location_table,
@@ -154,8 +187,11 @@ impl MirAnalyzer<'_> {
                 borrow_locals,
                 basic_blocks,
                 fn_id,
+                file_hash,
+                mir_hash,
             }
-        })
+        });
+        MirAnalyzerInitResult::Analyzer(analyzer)
     }
 
     fn sort_locs(v: &mut [(BasicBlock, usize)]) {
@@ -540,17 +576,19 @@ impl MirAnalyzer<'_> {
     }
 
     /// analyze MIR to get JSON-serializable, TypeScript friendly representation
-    pub fn analyze(self) -> (String, Function) {
+    pub fn analyze(self) -> AnalyzeResult {
         let decls = self.collect_decls();
         let basic_blocks = self.basic_blocks;
 
-        (
-            self.filename,
-            Function {
+        AnalyzeResult {
+            file_name: self.file_name,
+            file_hash: self.file_hash,
+            mir_hash: self.mir_hash,
+            analyzed: Function {
                 fn_id: self.fn_id.local_def_index.as_u32(),
                 basic_blocks,
                 decls,
             },
-        )
+        }
     }
 }

--- a/src/bin/core/cache.rs
+++ b/src/bin/core/cache.rs
@@ -6,6 +6,9 @@ use rustowl::models::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::Write;
+use std::sync::{LazyLock, Mutex};
+
+pub static CACHE: LazyLock<Mutex<Option<CacheData>>> = LazyLock::new(|| Mutex::new(None));
 
 #[derive(Debug, Clone)]
 struct StableHashString(String);
@@ -19,7 +22,7 @@ impl FromStableHash for StableHashString {
     fn from(hash: Self::Hash) -> Self {
         let byte0 = hash.0[0] as u128;
         let byte1 = hash.0[1] as u128;
-        let byte = (byte0 << 64) & byte1;
+        let byte = (byte0 << 64) | byte1;
         Self(format!("{byte:x}"))
     }
 }
@@ -33,7 +36,7 @@ impl<'tcx> Hasher<'tcx> {
     pub fn new(tcx: TyCtxt<'tcx>) -> Self {
         Self {
             hasher: StableHasher::default(),
-            hash_ctx: StableHashingContext::new(&tcx.sess, tcx.untracked()),
+            hash_ctx: StableHashingContext::new(tcx.sess, tcx.untracked()),
         }
     }
 
@@ -65,43 +68,50 @@ impl CacheData {
         Self(HashMap::new())
     }
     pub fn get_cache(&self, file_hash: &str, mir_hash: &str) -> Option<Function> {
-        self.0
-            .get(file_hash)
-            .map(|v| v.get(mir_hash))
-            .flatten()
-            .cloned()
+        self.0.get(file_hash).and_then(|v| v.get(mir_hash)).cloned()
     }
     pub fn insert_cache(&mut self, file_hash: String, mir_hash: String, analyzed: Function) {
         self.0
             .entry(file_hash)
-            .or_insert(HashMap::new())
+            .or_default()
             .insert(mir_hash, analyzed);
     }
 }
 
-/// Incremental hash file is a map.
-/// MIR body hash -> analyzed result.
-pub fn get_incremental_cache() -> Option<CacheData> {
-    if let Some(cache_path) = rustowl::cache::get_incremental_path() {
+/// Get cache data
+///
+/// If cache is not enabled, then return None.
+/// If file is not exists, it returns empty [`CacheData`].
+pub fn get_cache(krate: &str) -> Option<CacheData> {
+    if let Some(cache_path) = rustowl::cache::get_cache_path() {
+        let cache_path = cache_path.join(format!("{krate}.json"));
         let s = match std::fs::read_to_string(&cache_path) {
             Ok(v) => v,
             Err(e) => {
                 log::warn!("failed to read incremental cache file: {e}");
-                return None;
+                return Some(CacheData::new());
             }
         };
-        serde_json::from_str(&s).ok()
+        let read = serde_json::from_str(&s).ok();
+        log::info!("cache read: {}", cache_path.display());
+        read
     } else {
         None
     }
 }
 
-pub fn write_incremental_cache(cache: &CacheData) {
-    if let Some(cache_path) = rustowl::cache::get_incremental_path() {
+pub fn write_cache(krate: &str, cache: &CacheData) {
+    if let Some(cache_path) = rustowl::cache::get_cache_path() {
+        if let Err(e) = std::fs::create_dir_all(&cache_path) {
+            log::warn!("failed to create cache dir: {e}");
+            return;
+        }
+        let cache_path = cache_path.join(format!("{krate}.json"));
         let s = serde_json::to_string(cache).unwrap();
         let mut f = match std::fs::OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open(&cache_path)
         {
             Ok(v) => v,
@@ -113,5 +123,6 @@ pub fn write_incremental_cache(cache: &CacheData) {
         if let Err(e) = f.write_all(s.as_bytes()) {
             log::warn!("failed to write incremental cache file: {e}");
         }
+        log::info!("incremental cache saved: {}", cache_path.display());
     }
 }

--- a/src/bin/core/cache.rs
+++ b/src/bin/core/cache.rs
@@ -1,0 +1,117 @@
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_middle::ty::TyCtxt;
+use rustc_query_system::ich::StableHashingContext;
+use rustc_stable_hash::{FromStableHash, SipHasher128Hash};
+use rustowl::models::*;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::Write;
+
+#[derive(Debug, Clone)]
+struct StableHashString(String);
+impl StableHashString {
+    pub fn get(self) -> String {
+        self.0
+    }
+}
+impl FromStableHash for StableHashString {
+    type Hash = SipHasher128Hash;
+    fn from(hash: Self::Hash) -> Self {
+        let byte0 = hash.0[0] as u128;
+        let byte1 = hash.0[1] as u128;
+        let byte = (byte0 << 64) & byte1;
+        Self(format!("{byte:x}"))
+    }
+}
+
+pub struct Hasher<'a> {
+    hasher: StableHasher,
+    hash_ctx: StableHashingContext<'a>,
+}
+
+impl<'tcx> Hasher<'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Self {
+            hasher: StableHasher::default(),
+            hash_ctx: StableHashingContext::new(&tcx.sess, tcx.untracked()),
+        }
+    }
+
+    fn finish(self) -> String {
+        self.hasher.finish::<StableHashString>().get()
+    }
+
+    pub fn get_hash(
+        tcx: TyCtxt<'tcx>,
+        target: impl HashStable<StableHashingContext<'tcx>>,
+    ) -> String {
+        let mut new = Self::new(tcx);
+        target.hash_stable(&mut new.hash_ctx, &mut new.hasher);
+        new.finish()
+    }
+}
+
+/// Single file cache body
+///
+/// this is a map: file hash -> (MIR body hash -> analyze result)
+///
+/// Note: Cache can be utilized when neither
+/// the MIR body nor the entire file is modified.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct CacheData(HashMap<String, HashMap<String, Function>>);
+impl CacheData {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+    pub fn get_cache(&self, file_hash: &str, mir_hash: &str) -> Option<Function> {
+        self.0
+            .get(file_hash)
+            .map(|v| v.get(mir_hash))
+            .flatten()
+            .cloned()
+    }
+    pub fn insert_cache(&mut self, file_hash: String, mir_hash: String, analyzed: Function) {
+        self.0
+            .entry(file_hash)
+            .or_insert(HashMap::new())
+            .insert(mir_hash, analyzed);
+    }
+}
+
+/// Incremental hash file is a map.
+/// MIR body hash -> analyzed result.
+pub fn get_incremental_cache() -> Option<CacheData> {
+    if let Some(cache_path) = rustowl::cache::get_incremental_path() {
+        let s = match std::fs::read_to_string(&cache_path) {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!("failed to read incremental cache file: {e}");
+                return None;
+            }
+        };
+        serde_json::from_str(&s).ok()
+    } else {
+        None
+    }
+}
+
+pub fn write_incremental_cache(cache: &CacheData) {
+    if let Some(cache_path) = rustowl::cache::get_incremental_path() {
+        let s = serde_json::to_string(cache).unwrap();
+        let mut f = match std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&cache_path)
+        {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!("failed to open incremental cache file: {e}");
+                return;
+            }
+        };
+        if let Err(e) = f.write_all(s.as_bytes()) {
+            log::warn!("failed to write incremental cache file: {e}");
+        }
+    }
+}

--- a/src/bin/core/mir_transform.rs
+++ b/src/bin/core/mir_transform.rs
@@ -1,0 +1,26 @@
+use rustc_middle::{
+    mir::Body,
+    ty::{TyCtxt, TypeFoldable, TypeFolder},
+};
+
+struct RegionEraser<'tcx> {
+    tcx: TyCtxt<'tcx>,
+}
+
+impl<'tcx> TypeFolder<TyCtxt<'tcx>> for RegionEraser<'tcx> {
+    fn cx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+    fn fold_region(
+        &mut self,
+        _r: <TyCtxt<'tcx> as rustc_type_ir::Interner>::Region,
+    ) -> <TyCtxt<'tcx> as rustc_type_ir::Interner>::Region {
+        self.tcx.lifetimes.re_static
+    }
+}
+
+pub fn erase_region_variables<'tcx>(tcx: TyCtxt<'tcx>, body: Body<'tcx>) -> Body<'tcx> {
+    let mut eraser = RegionEraser { tcx };
+
+    body.fold_with(&mut eraser)
+}

--- a/src/bin/rustowlc.rs
+++ b/src/bin/rustowlc.rs
@@ -7,6 +7,7 @@
 pub extern crate indexmap;
 pub extern crate polonius_engine;
 pub extern crate rustc_borrowck;
+pub extern crate rustc_data_structures;
 pub extern crate rustc_driver;
 pub extern crate rustc_errors;
 pub extern crate rustc_hash;
@@ -14,12 +15,12 @@ pub extern crate rustc_hir;
 pub extern crate rustc_index;
 pub extern crate rustc_interface;
 pub extern crate rustc_middle;
+pub extern crate rustc_query_system;
 pub extern crate rustc_session;
 pub extern crate rustc_span;
-pub extern crate smallvec;
 pub extern crate rustc_stable_hash;
-pub extern crate rustc_data_structures;
-pub extern crate rustc_query_system;
+pub extern crate rustc_type_ir;
+pub extern crate smallvec;
 
 pub mod core;
 

--- a/src/bin/rustowlc.rs
+++ b/src/bin/rustowlc.rs
@@ -17,6 +17,9 @@ pub extern crate rustc_middle;
 pub extern crate rustc_session;
 pub extern crate rustc_span;
 pub extern crate smallvec;
+pub extern crate rustc_stable_hash;
+pub extern crate rustc_data_structures;
+pub extern crate rustc_query_system;
 
 pub mod core;
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,22 @@
+use std::env;
+use std::path::{Path, PathBuf};
+use tokio::process::Command;
+
+pub fn is_incremental() -> bool {
+    env::var("RUSTOWL_INCREMENTAL")
+        .map(|v| v != "false" && v != "0")
+        .unwrap_or(true)
+}
+
+pub fn set_incremental_path(cmd: &mut Command, target_dir: impl AsRef<Path>) {
+    cmd.env(
+        "RUSTOWL_INCREMENTAL_CACHE",
+        target_dir.as_ref().join("incremental_cache.json"),
+    );
+}
+
+pub fn get_incremental_path() -> Option<PathBuf> {
+    env::var("RUSTOWL_INCREMENTAL_CACHE")
+        .map(|v| PathBuf::from(v))
+        .ok()
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,21 +2,16 @@ use std::env;
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
-pub fn is_incremental() -> bool {
-    env::var("RUSTOWL_INCREMENTAL")
-        .map(|v| v != "false" && v != "0")
-        .unwrap_or(true)
+pub fn is_cache() -> bool {
+    !env::var("RUSTOWL_CACHE")
+        .map(|v| v == "false" || v == "0")
+        .unwrap_or(false)
 }
 
-pub fn set_incremental_path(cmd: &mut Command, target_dir: impl AsRef<Path>) {
-    cmd.env(
-        "RUSTOWL_INCREMENTAL_CACHE",
-        target_dir.as_ref().join("incremental_cache.json"),
-    );
+pub fn set_cache_path(cmd: &mut Command, target_dir: impl AsRef<Path>) {
+    cmd.env("RUSTOWL_CACHE_DIR", target_dir.as_ref().join("cache"));
 }
 
-pub fn get_incremental_path() -> Option<PathBuf> {
-    env::var("RUSTOWL_INCREMENTAL_CACHE")
-        .map(|v| PathBuf::from(v))
-        .ok()
+pub fn get_cache_path() -> Option<PathBuf> {
+    env::var("RUSTOWL_CACHE_DIR").map(PathBuf::from).ok()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Libraries that used in RustOwl
 
+pub mod cache;
 pub mod cli;
 pub mod lsp;
 pub mod models;

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -184,8 +184,8 @@ impl Backend {
             let sysroot = toolchain::get_sysroot().await;
             toolchain::set_rustc_env(&mut command, &sysroot);
 
-            if is_incremental() {
-                set_incremental_path(&mut command, &target);
+            if is_cache() {
+                set_cache_path(&mut command, &target);
             }
 
             if log::max_level().to_level().is_none() {


### PR DESCRIPTION
## Related Issue(s)

Related to #207 .

## Description

`rustowlc` saves cache as `[target]/cache/[crate_name].json`.
This cache saves the hash of each file and the hash of each MIR body.
We can use cached results when a file is not changed and a function's MIR body is not changed.

This cache mechanism may not be the best method.
But we can implement a cache mechanism based on this code.