### PR TITLE
Add background highlight option for VSCode extension 

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -44,32 +44,37 @@
         "rustowl.lifetimeColor": {
           "type": "string",
           "default": "hsla(125, 80%, 60%, 0.6)",
-          "description": "The color of the lifetime underline"
+          "description": "The color of the lifetime"
         },
         "rustowl.moveCallColor": {
           "type": "string",
           "default": "hsla(35, 80%, 60%, 0.6)",
-          "description": "The color of the move/call underline"
+          "description": "The color of the move/call"
         },
         "rustowl.immutableBorrowColor": {
           "type": "string",
           "default": "hsla(230, 80%, 60%, 0.6)",
-          "description": "The color of the immutable borrow underline"
+          "description": "The color of the immutable borrow"
         },
         "rustowl.mutableBorrowColor": {
           "type": "string",
           "default": "hsla(300, 80%, 60%, 0.6)",
-          "description": "The color of the mutable borrow underline"
+          "description": "The color of the mutable borrow"
         },
         "rustowl.outliveColor": {
           "type": "string",
           "default": "hsla(0, 80%, 60%, 0.6)",
-          "description": "The color of the outlive underline"
+          "description": "The color of the outlive"
         },
         "rustowl.displayDelay": {
           "type": "number",
           "default": 2000,
           "description": "Delay in displaying underlines (ms)"
+        },
+        "rustowl.highlightBackground": {
+          "type": "boolean",
+          "default": false,
+          "description": "Highlight text background instead of underline"
         }
       }
     }

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -93,10 +93,10 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     lifetimeDecorationType = createDecorationType(lifetimeColor, highlightBackground);
-    moveDecorationType = createDecorationType(lifetimeColor, moveCallColor);
-    imBorrowDecorationType = createDecorationType(lifetimeColor, immutableBorrowColor);
-    mBorrowDecorationType = createDecorationType(lifetimeColor, mutableBorrowColor);
-    outLiveDecorationType = createDecorationType(lifetimeColor, outliveColor);
+    moveDecorationType = createDecorationType(moveCallColor, highlightBackground);
+    imBorrowDecorationType = createDecorationType(immutableBorrowColor, highlightBackground);
+    mBorrowDecorationType = createDecorationType(mutableBorrowColor, highlightBackground);
+    outLiveDecorationType = createDecorationType(outliveColor, highlightBackground);
     emptyDecorationType = vscode.window.createTextEditorDecorationType({});
 
     const lifetime: vscode.DecorationOptions[] = [];

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -79,23 +79,24 @@ export function activate(context: vscode.ExtensionContext) {
       immutableBorrowColor,
       mutableBorrowColor,
       outliveColor,
+      highlightBackground
     } = vscode.workspace.getConfiguration("rustowl");
 
-    lifetimeDecorationType = vscode.window.createTextEditorDecorationType({
-      textDecoration: `underline solid ${underlineThickness}px ${lifetimeColor}`,
-    });
-    moveDecorationType = vscode.window.createTextEditorDecorationType({
-      textDecoration: `underline solid ${underlineThickness}px ${moveCallColor}`,
-    });
-    imBorrowDecorationType = vscode.window.createTextEditorDecorationType({
-      textDecoration: `underline solid ${underlineThickness}px ${immutableBorrowColor}`,
-    });
-    mBorrowDecorationType = vscode.window.createTextEditorDecorationType({
-      textDecoration: `underline solid ${underlineThickness}px ${mutableBorrowColor}`,
-    });
-    outLiveDecorationType = vscode.window.createTextEditorDecorationType({
-      textDecoration: `underline solid ${underlineThickness}px ${outliveColor}`,
-    });
+    function createDecorationType(color: string, highlightBackground: boolean): vscode.TextEditorDecorationType {
+      return highlightBackground
+        ? vscode.window.createTextEditorDecorationType({
+            backgroundColor: color,
+          })
+        : vscode.window.createTextEditorDecorationType({
+            textDecoration: `underline solid ${underlineThickness}px ${color}`,
+          });
+    }
+
+    lifetimeDecorationType = createDecorationType(lifetimeColor, highlightBackground);
+    moveDecorationType = createDecorationType(lifetimeColor, moveCallColor);
+    imBorrowDecorationType = createDecorationType(lifetimeColor, immutableBorrowColor);
+    mBorrowDecorationType = createDecorationType(lifetimeColor, mutableBorrowColor);
+    outLiveDecorationType = createDecorationType(lifetimeColor, outliveColor);
     emptyDecorationType = vscode.window.createTextEditorDecorationType({});
 
     const lifetime: vscode.DecorationOptions[] = [];

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -79,10 +79,13 @@ export function activate(context: vscode.ExtensionContext) {
       immutableBorrowColor,
       mutableBorrowColor,
       outliveColor,
-      highlightBackground
+      highlightBackground,
     } = vscode.workspace.getConfiguration("rustowl");
 
-    function createDecorationType(color: string, highlightBackground: boolean): vscode.TextEditorDecorationType {
+    function createDecorationType(
+      color: string,
+      highlightBackground: boolean,
+    ): vscode.TextEditorDecorationType {
       return highlightBackground
         ? vscode.window.createTextEditorDecorationType({
             backgroundColor: color,
@@ -92,11 +95,26 @@ export function activate(context: vscode.ExtensionContext) {
           });
     }
 
-    lifetimeDecorationType = createDecorationType(lifetimeColor, highlightBackground);
-    moveDecorationType = createDecorationType(moveCallColor, highlightBackground);
-    imBorrowDecorationType = createDecorationType(immutableBorrowColor, highlightBackground);
-    mBorrowDecorationType = createDecorationType(mutableBorrowColor, highlightBackground);
-    outLiveDecorationType = createDecorationType(outliveColor, highlightBackground);
+    lifetimeDecorationType = createDecorationType(
+      lifetimeColor,
+      highlightBackground,
+    );
+    moveDecorationType = createDecorationType(
+      moveCallColor,
+      highlightBackground,
+    );
+    imBorrowDecorationType = createDecorationType(
+      immutableBorrowColor,
+      highlightBackground,
+    );
+    mBorrowDecorationType = createDecorationType(
+      mutableBorrowColor,
+      highlightBackground,
+    );
+    outLiveDecorationType = createDecorationType(
+      outliveColor,
+      highlightBackground,
+    );
     emptyDecorationType = vscode.window.createTextEditorDecorationType({});
 
     const lifetime: vscode.DecorationOptions[] = [];


### PR DESCRIPTION
I thought it would've been cool to have background highlight option and decided to implement it.

Here is the result:

<img width="572" height="262" alt="image" src="https://github.com/user-attachments/assets/e47ed863-d3e2-4edc-a1f0-b77f369b5d49" />

- Also added new checkmark in RustOwl Settings
<img width="572" height="106" alt="image" src="https://github.com/user-attachments/assets/0d76624d-cdda-426d-ac2a-570b234a36fe" />