### PR TITLE
feat(config): add configurable highlight colors for neovim plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Minimal setup with [lazy.nvim](https://github.com/folke/lazy.nvim):
 }
 ```
 
+For comprehensive configuration options including custom highlight colors, see the [Neovim Configuration Guide](docs/neovim-configuration.md).
+
 <details>
 <summary>Recommended configuration: <b>Click to expand</b></summary>
 
@@ -167,8 +169,41 @@ Default options:
   idle_time = 500, -- Time in milliseconds to hover with the cursor before triggering RustOwl
   client = {}, -- LSP client configuration that gets passed to `vim.lsp.start`
   highlight_style = 'undercurl', -- You can also use 'underline'
+  colors = { -- Customize highlight colors (hex colors)
+    lifetime = '#00cc00',   -- 🟩 green: variable's actual lifetime
+    imm_borrow = '#0000cc', -- 🟦 blue: immutable borrowing
+    mut_borrow = '#cc00cc', -- 🟪 purple: mutable borrowing
+    move = '#cccc00',       -- 🟧 orange: value moved
+    call = '#cccc00',       -- 🟧 orange: function call
+    outlive = '#cc0000',    -- 🟥 red: lifetime error
+  },
 }
 ```
+
+#### Customizing Highlight Colors
+
+You can customize the colors used for different highlight types by setting the `colors` option in your configuration:
+
+```lua
+{
+  'cordx56/rustowl',
+  version = '*',
+  build = 'cargo binstall rustowl',
+  lazy = false,
+  opts = {
+    colors = {
+      lifetime = '#32cd32',   -- Lime green for lifetimes
+      imm_borrow = '#4169e1', -- Royal blue for immutable borrows
+      mut_borrow = '#ff69b4', -- Hot pink for mutable borrows
+      move = '#ffa500',       -- Orange for moves
+      call = '#ffd700',       -- Gold for function calls
+      outlive = '#dc143c',    -- Crimson for lifetime errors
+    },
+  },
+}
+```
+
+Each color should be specified as a hex color string (e.g., `'#ff0000'` for red).
 
 When opening a Rust file, the Neovim plugin creates the `Rustowl` user command:
 

--- a/README.md
+++ b/README.md
@@ -180,31 +180,6 @@ Default options:
 }
 ```
 
-#### Customizing Highlight Colors
-
-You can customize the colors used for different highlight types by setting the `colors` option in your configuration:
-
-```lua
-{
-  'cordx56/rustowl',
-  version = '*',
-  build = 'cargo binstall rustowl',
-  lazy = false,
-  opts = {
-    colors = {
-      lifetime = '#32cd32',   -- Lime green for lifetimes
-      imm_borrow = '#4169e1', -- Royal blue for immutable borrows
-      mut_borrow = '#ff69b4', -- Hot pink for mutable borrows
-      move = '#ffa500',       -- Orange for moves
-      call = '#ffd700',       -- Gold for function calls
-      outlive = '#dc143c',    -- Crimson for lifetime errors
-    },
-  },
-}
-```
-
-Each color should be specified as a hex color string (e.g., `'#ff0000'` for red).
-
 When opening a Rust file, the Neovim plugin creates the `Rustowl` user command:
 
 ```vim

--- a/docs/neovim-configuration.md
+++ b/docs/neovim-configuration.md
@@ -1,0 +1,254 @@
+# RustOwl Configuration (Neovim)
+
+This document describes all available configuration options for the RustOwl Neovim plugin.
+
+## Table of Contents
+
+- [Basic Setup](#basic-setup)
+- [Configuration Options](#configuration-options)
+- [Customizing Highlight Colors](#customizing-highlight-colors)
+- [Examples](#examples)
+
+## Basic Setup
+
+The minimal configuration for RustOwl using [lazy.nvim](https://github.com/folke/lazy.nvim):
+
+```lua
+{
+  'cordx56/rustowl',
+  version = '*', -- Latest stable version
+  build = 'cargo binstall rustowl',
+  lazy = false, -- This plugin is already lazy
+  opts = {},
+}
+```
+
+## Configuration Options
+
+All configuration options are optional and have sensible defaults:
+
+### `auto_attach` (boolean)
+
+- **Default**: `true`
+- **Description**: Automatically attach the RustOwl LSP client when opening a Rust file.
+
+### `auto_enable` (boolean)
+
+- **Default**: `false`
+- **Description**: Enable RustOwl highlighting immediately when the LSP client attaches. When `false`, you need to manually enable highlighting using `:Rustowl enable` or `require('rustowl').enable()`.
+
+### `idle_time` (number)
+
+- **Default**: `500`
+- **Description**: Time in milliseconds to hover with the cursor before triggering RustOwl analysis and highlighting.
+
+### `highlight_style` (string)
+
+- **Default**: `'undercurl'`
+- **Options**: `'undercurl'` or `'underline'`
+- **Description**: The style of underline to use for highlighting.
+
+### `colors` (table)
+
+- **Description**: Custom colors for different highlight types. Each color should be a hex color string (e.g., `'#ff0000'`).
+
+#### Available Color Options:
+
+- `lifetime`: Color for variable lifetime highlights (default: `'#00cc00'` - green)
+- `imm_borrow`: Color for immutable borrow highlights (default: `'#0000cc'` - blue)
+- `mut_borrow`: Color for mutable borrow highlights (default: `'#cc00cc'` - purple)
+- `move`: Color for value move highlights (default: `'#cccc00'` - yellow)
+- `call`: Color for function call highlights (default: `'#cccc00'` - yellow)
+- `outlive`: Color for lifetime error highlights (default: `'#cc0000'` - red)
+
+### `client` (table)
+
+- **Description**: LSP client configuration that gets passed to `vim.lsp.start`. This follows the same structure as Neovim's LSP client configuration.
+
+## Customizing Highlight Colors
+
+### Default Colors
+
+The default color scheme uses the following colors that correspond to the visual legend:
+
+- 🟩 **Green** (`#00cc00`): Variable's actual lifetime
+- 🟦 **Blue** (`#0000cc`): Immutable borrowing
+- 🟪 **Purple** (`#cc00cc`): Mutable borrowing
+- 🟧 **Yellow** (`#cccc00`): Value moved / function call
+- 🟥 **Red** (`#cc0000`): Lifetime errors
+
+### Custom Colors
+
+To customize colors, specify them in the `colors` table:
+
+```lua
+opts = {
+  colors = {
+    lifetime = '#32cd32',   -- Lime green
+    imm_borrow = '#4169e1', -- Royal blue
+    mut_borrow = '#ff69b4', -- Hot pink
+    move = '#ffa500',       -- Orange
+    call = '#ffd700',       -- Gold
+    outlive = '#dc143c',    -- Crimson
+  },
+}
+```
+
+#### Color Format
+
+Colors must be specified as hex color strings:
+
+- ✅ Valid: `'#ff0000'`, `'#00ff00'`, `'#0000ff'`
+- ❌ Invalid: `'red'`, `'rgb(255,0,0)'`, `'#f00'`
+
+### Partial Color Customization
+
+You can customize only specific colors while keeping the defaults for others:
+
+```lua
+opts = {
+  colors = {
+    lifetime = '#90ee90',   -- Light green for better visibility
+    outlive = '#ff4500',    -- Orange red for errors
+    -- Other colors will use defaults
+  },
+}
+```
+
+## Examples
+
+### Example 1: Minimal Configuration
+
+```lua
+{
+  'cordx56/rustowl',
+  version = '*',
+  build = 'cargo binstall rustowl',
+  lazy = false,
+  opts = {},
+}
+```
+
+### Example 2: Auto-enable with Custom Colors
+
+```lua
+{
+  'cordx56/rustowl',
+  version = '*',
+  build = 'cargo binstall rustowl',
+  lazy = false,
+  opts = {
+    auto_enable = true,
+    colors = {
+      lifetime = '#90ee90',   -- Light green
+      imm_borrow = '#87ceeb', -- Sky blue
+      mut_borrow = '#dda0dd', -- Plum
+      move = '#f0e68c',       -- Khaki
+      call = '#ffd700',       -- Gold
+      outlive = '#ff6347',    -- Tomato
+    },
+  },
+}
+```
+
+### Example 3: Custom Key Binding and Styling
+
+```lua
+{
+  'cordx56/rustowl',
+  version = '*',
+  build = 'cargo binstall rustowl',
+  lazy = false,
+  opts = {
+    auto_enable = false,
+    idle_time = 300,
+    highlight_style = 'underline',
+    colors = {
+      outlive = '#ff0000', -- Bright red for errors
+    },
+    client = {
+      on_attach = function(_, buffer)
+        vim.keymap.set('n', '<leader>ro', function()
+          require('rustowl').toggle(buffer)
+        end, { buffer = buffer, desc = 'Toggle RustOwl' })
+
+        vim.keymap.set('n', '<leader>re', function()
+          require('rustowl').enable(buffer)
+        end, { buffer = buffer, desc = 'Enable RustOwl' })
+
+        vim.keymap.set('n', '<leader>rd', function()
+          require('rustowl').disable(buffer)
+        end, { buffer = buffer, desc = 'Disable RustOwl' })
+      end
+    },
+  },
+}
+```
+
+### Example 4: Dark Theme Optimized Colors
+
+```lua
+{
+  'cordx56/rustowl',
+  version = '*',
+  build = 'cargo binstall rustowl',
+  lazy = false,
+  opts = {
+    colors = {
+      lifetime = '#50fa7b',   -- Dracula green
+      imm_borrow = '#8be9fd', -- Dracula cyan
+      mut_borrow = '#ff79c6', -- Dracula pink
+      move = '#f1fa8c',       -- Dracula yellow
+      call = '#ffb86c',       -- Dracula orange
+      outlive = '#ff5555',    -- Dracula red
+    },
+  },
+}
+```
+
+### Example 5: For init.vim Users
+
+If you're using `init.vim` instead of `init.lua`, you can configure RustOwl using Vim script:
+
+```vim
+lua << EOF
+require('lazy').setup({
+  {
+    'cordx56/rustowl',
+    version = '*',
+    build = 'cargo binstall rustowl',
+    lazy = false,
+    opts = {
+      colors = {
+        lifetime = '#00ff00',
+        imm_borrow = '#0080ff',
+        mut_borrow = '#ff00ff',
+        move = '#ffff00',
+        call = '#ffa500',
+        outlive = '#ff0000',
+      },
+    },
+  },
+})
+EOF
+```
+
+## Usage Commands
+
+When opening a Rust file, the following commands become available:
+
+- `:Rustowl start_client` - Start the RustOwl LSP client
+- `:Rustowl stop_client` - Stop the RustOwl LSP client
+- `:Rustowl restart_client` - Restart the RustOwl LSP client
+- `:Rustowl enable` - Enable RustOwl highlighting
+- `:Rustowl disable` - Disable RustOwl highlighting
+- `:Rustowl toggle` - Toggle RustOwl highlighting
+
+You can also use the Lua API:
+
+```lua
+require('rustowl').enable()   -- Enable highlighting
+require('rustowl').disable()  -- Disable highlighting
+require('rustowl').toggle()   -- Toggle highlighting
+require('rustowl').is_enabled() -- Check if enabled
+```

--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -5,14 +5,15 @@ if not vim.g.loaded_rustowl then
 
   local highlight_style = config.highlight_style or 'undercurl'
 
-  local highlights = {
-    lifetime = '#00cc00',
-    imm_borrow = '#0000cc',
-    mut_borrow = '#cc00cc',
-    move = '#cccc00',
-    call = '#cccc00',
-    outlive = '#cc0000',
-  }
+  local highlights = config.colors
+    or {
+      lifetime = '#00cc00',
+      imm_borrow = '#0000cc',
+      mut_borrow = '#cc00cc',
+      move = '#cccc00',
+      call = '#cccc00',
+      outlive = '#cc0000',
+    }
 
   for hl_name, color in pairs(highlights) do
     local options = { default = true, sp = color }

--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -5,15 +5,17 @@ if not vim.g.loaded_rustowl then
 
   local highlight_style = config.highlight_style or 'undercurl'
 
-  local highlights = config.colors
-    or {
-      lifetime = '#00cc00',
-      imm_borrow = '#0000cc',
-      mut_borrow = '#cc00cc',
-      move = '#cccc00',
-      call = '#cccc00',
-      outlive = '#cc0000',
-    }
+  local default_colors = {
+    lifetime = '#00cc00',
+    imm_borrow = '#0000cc',
+    mut_borrow = '#cc00cc',
+    move = '#cccc00',
+    call = '#cccc00',
+    outlive = '#cc0000',
+  }
+
+  -- Ensure all color keys are present even if user provides a partial table
+  local highlights = vim.tbl_deep_extend('keep', config.colors or {}, default_colors)
 
   for hl_name, color in pairs(highlights) do
     local options = { default = true, sp = color }

--- a/lua/rustowl/config.lua
+++ b/lua/rustowl/config.lua
@@ -12,8 +12,35 @@
 ---Time in milliseconds to hover with the cursor before triggering RustOwl
 ---@field idle_time? number
 ---
+---The highlight style to use for underlines ('undercurl' or 'underline')
+---Default: `'undercurl'`
+---@field highlight_style? string
+---
+---Custom colors for different highlight types
+---@field colors? rustowl.Colors
+---
 ---The LSP client config (This can also be set using |vim.lsp.config()|).
 ---@field client? rustowl.ClientConfig
+
+---@class rustowl.Colors
+---
+---Color for lifetime highlights (default: '#00cc00')
+---@field lifetime? string
+---
+---Color for immutable borrow highlights (default: '#0000cc')
+---@field imm_borrow? string
+---
+---Color for mutable borrow highlights (default: '#cc00cc')
+---@field mut_borrow? string
+---
+---Color for move highlights (default: '#cccc00')
+---@field move? string
+---
+---Color for function call highlights (default: '#cccc00')
+---@field call? string
+---
+---Color for outlive error highlights (default: '#cc0000')
+---@field outlive? string
 
 ---NOTE: This allows lua-language-server to provide users
 ---completions and hover when setting vim.g.rustowl directly.
@@ -40,6 +67,16 @@ local default_config = {
 
   ---@type string
   highlight_style = 'undercurl',
+
+  ---@type rustowl.Colors
+  colors = {
+    lifetime = '#00cc00',
+    imm_borrow = '#0000cc',
+    mut_borrow = '#cc00cc',
+    move = '#cccc00',
+    call = '#cccc00',
+    outlive = '#cc0000',
+  },
 
   ---@class rustowl.internal.ClientConfig: vim.lsp.ClientConfig
 
@@ -72,6 +109,7 @@ vim.validate {
   idle_time = { config.idle_time, 'number' },
   client = { config.client, { 'table' } },
   highlight_style = { config.highlight_style, 'string' },
+  colors = { config.colors, 'table' },
 }
 
 -- validation for highlight_style to ensure undercurl or underline

--- a/nvim-tests/test_color_config.lua
+++ b/nvim-tests/test_color_config.lua
@@ -1,0 +1,78 @@
+local MiniTest = require('mini.test')
+local expect = MiniTest.expect
+
+local function monkeypatch_vim_lsp_config()
+  -- Patch: ensure vim.lsp and vim.lsp.config exist and are tables, and rustowl is a table
+  if not vim.lsp then
+    vim.lsp = {}
+  end
+  if not vim.lsp.config then
+    vim.lsp.config = {}
+  end
+  vim.lsp.config.rustowl = {}
+end
+
+local T = MiniTest.new_set {
+  hooks = {
+    pre_case = function()
+      -- Reset vim.g.rustowl before each test
+      vim.g.rustowl = nil
+      -- Reload the config module to get fresh state
+      package.loaded['rustowl.config'] = nil
+      monkeypatch_vim_lsp_config()
+    end,
+  },
+}
+
+T['default colors'] = function()
+  vim.g.rustowl = {}
+  local config = require('rustowl.config')
+
+  expect.equality(config.colors.lifetime, '#00cc00')
+  expect.equality(config.colors.imm_borrow, '#0000cc')
+  expect.equality(config.colors.mut_borrow, '#cc00cc')
+  expect.equality(config.colors.move, '#cccc00')
+  expect.equality(config.colors.call, '#cccc00')
+  expect.equality(config.colors.outlive, '#cc0000')
+end
+
+T['custom colors'] = function()
+  vim.g.rustowl = {
+    colors = {
+      lifetime = '#32cd32',
+      imm_borrow = '#4169e1',
+      mut_borrow = '#ff69b4',
+      move = '#ffa500',
+      call = '#ffd700',
+      outlive = '#dc143c',
+    },
+  }
+  local config = require('rustowl.config')
+
+  expect.equality(config.colors.lifetime, '#32cd32')
+  expect.equality(config.colors.imm_borrow, '#4169e1')
+  expect.equality(config.colors.mut_borrow, '#ff69b4')
+  expect.equality(config.colors.move, '#ffa500')
+  expect.equality(config.colors.call, '#ffd700')
+  expect.equality(config.colors.outlive, '#dc143c')
+end
+
+T['partial color customization'] = function()
+  vim.g.rustowl = {
+    colors = {
+      lifetime = '#90ee90',
+      outlive = '#ff4500',
+      -- Other colors should use defaults
+    },
+  }
+  local config = require('rustowl.config')
+
+  expect.equality(config.colors.lifetime, '#90ee90')
+  expect.equality(config.colors.imm_borrow, '#0000cc') -- default
+  expect.equality(config.colors.mut_borrow, '#cc00cc') -- default
+  expect.equality(config.colors.move, '#cccc00') -- default
+  expect.equality(config.colors.call, '#cccc00') -- default
+  expect.equality(config.colors.outlive, '#ff4500')
+end
+
+return T


### PR DESCRIPTION
Add comprehensive color customization system allowing users to configure
all highlight colors (lifetime, imm_borrow, mut_borrow, move, call, outlive)
through plugin configuration.

- Add `@class` rustowl.Colors type definition with validation
- Update ftplugin to use configured colors with fallback defaults
- Add complete configuration documentation with examples
- Include tests for default, full custom, and partial customization
- Maintain backward compatibility for existing configurations

fixes #49
