### PR TITLE
refactor(ci): check build on main push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,8 @@
 name: Build RustOwl
 
 on:
+  push:
+    branches: ["main"]
   workflow_call:
     outputs:
       run_id:
@@ -8,11 +10,7 @@ on:
         value: ${{ github.run_id }}
 
 jobs:
-  check:
-    uses: ./.github/workflows/checks.yml
-
   rustowl:
-    needs: [check]
     strategy:
       matrix:
         os:
@@ -68,6 +66,13 @@ jobs:
           else
             ./scripts/build/toolchain cargo build --profile=${{ env.build_profile }}
           fi
+
+      - name: Check the functionality
+        run: |
+          if [[ "${{ env.is_linux }}" == "true"  ]]; then
+            ./target/${{ env.host_tuple }}/${{ env.build_profile }}/rustowl${{ env.exec_ext }} check ./perf-tests/dummy-package
+          else
+            ./target/${{ env.build_profile }}/rustowl${{ env.exec_ext }} check ./perf-tests/dummy-package
 
       - name: Set archive name
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,7 +123,6 @@ jobs:
             ${{ env.archive_name }}
 
   vscode:
-    needs: check
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,8 +3,6 @@ name: Basic Checks
 on:
   pull_request:
     branches: ["main"]
-  push:
-    branches: ["main"]
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ permissions:
   contents: write
 
 jobs:
+  check:
+    uses: ./.github/workflows/checks.yml
   build:
     uses: ./.github/workflows/build.yaml
 
@@ -18,6 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pre_release: ${{ steps.pre-release.outputs.pre_release }}
+    needs:
+      - check
+      - build
     steps:
       - name: Check pre-release
         id: pre-release
@@ -31,9 +36,7 @@ jobs:
   crates-io-release:
     name: Create Crates.io release
     runs-on: ubuntu-latest
-    needs:
-      - build
-      - meta
+    needs: ["meta"]
     steps:
       - uses: actions/checkout@v4
       - name: Release crates.io
@@ -45,9 +48,7 @@ jobs:
   vscode-release:
     name: Create Vscode Release
     runs-on: ubuntu-latest
-    needs:
-      - build
-      - meta
+    needs: ["meta"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
@@ -66,9 +67,7 @@ jobs:
   vscodium-release:
     name: Create Vscodium Release
     runs-on: ubuntu-latest
-    needs:
-      - build
-      - meta
+    needs: ["meta"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
@@ -87,9 +86,7 @@ jobs:
   winget-release:
     name: Create Winget Release
     runs-on: windows-latest
-    needs:
-      - build
-      - meta
+    needs: ["meta"]
     steps:
       - uses: vedantmgoyal9/winget-releaser@main
         if: needs.meta.outputs.pre_release != 'true'
@@ -100,9 +97,7 @@ jobs:
   aur-release:
     name: Create AUR Release
     runs-on: ubuntu-latest
-    needs:
-      - build
-      - meta
+    needs: ["meta"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -142,9 +137,7 @@ jobs:
   github-release:
     name: Create A GitHub Release
     runs-on: ubuntu-latest
-    needs:
-      - build
-      - meta
+    needs: ["meta"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -176,6 +169,7 @@ jobs:
   docker-release:
     name: Release To GitHub Container Registry
     runs-on: ubuntu-latest
+    needs: ["meta"]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Description

Check the functionality for all architectures at build time.
Also, we do not need to run lint checks on pushes to main, since they are done before merging.
Instead, we now build for all architectures on pushes to main.