### PR TITLE
fix!: live range calculation now uses StorageLive/StorageDead

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -286,6 +286,8 @@ pub enum MirDecl {
         drop: bool,
         drop_range: Vec<Range>,
         must_live_at: Vec<Range>,
+        /// Range from StorageLive to StorageDead for this variable
+        storage_range: Vec<Range>,
     },
     Other {
         local: FnLocal,
@@ -296,6 +298,8 @@ pub enum MirDecl {
         drop: bool,
         drop_range: Vec<Range>,
         must_live_at: Vec<Range>,
+        /// Range from StorageLive to StorageDead for this variable
+        storage_range: Vec<Range>,
     },
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -60,6 +60,28 @@ pub fn eliminated_ranges(mut ranges: Vec<Range>) -> Vec<Range> {
     ranges
 }
 
+/// Compute intersection of two range lists.
+/// Returns ranges that are covered by both lists.
+pub fn intersect_ranges(ranges1: Vec<Range>, ranges2: Vec<Range>) -> Vec<Range> {
+    let mut result = Vec::new();
+    for r1 in &ranges1 {
+        for r2 in &ranges2 {
+            if let Some(common) = common_range(*r1, *r2) {
+                result.push(common);
+            }
+        }
+    }
+    eliminated_ranges(result)
+}
+
+/// Compute union of two range lists.
+/// Returns ranges that are covered by either list.
+pub fn union_ranges(ranges1: Vec<Range>, ranges2: Vec<Range>) -> Vec<Range> {
+    let mut combined = ranges1;
+    combined.extend(ranges2);
+    eliminated_ranges(combined)
+}
+
 pub fn exclude_ranges(mut from: Vec<Range>, excludes: Vec<Range>) -> Vec<Range> {
     let mut i = 0;
     'outer: while i < from.len() {


### PR DESCRIPTION
## Type Of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Enhancement
- [x] Breaking change
  - Only algorithm changes and no LSP API changes
- [ ] Other

## Description

Fix live range calculation algorithm.

Before:
<img width="529" height="471" alt="スクリーンショット 2026-01-26 20 59 13" src="https://github.com/user-attachments/assets/e075b046-c320-4bc9-876c-879882665c0b" />

After:
<img width="526" height="429" alt="スクリーンショット 2026-01-26 21 37 08" src="https://github.com/user-attachments/assets/a4894ee8-11ef-4f9b-8f5a-3ab00bd2ec88" />


