### PR TITLE
fix: select boxes are is considered as task list

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,14 +7,14 @@
 
 ## Type Of Change
 
-<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
+<!-- What types of changes does your code introduce? Remove the options that do not apply. -->
 
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Documentation update
-- [ ] Enhancement
-- [ ] Breaking change
-- [ ] Other
+- Bug fix
+- New feature
+- Documentation update
+- Enhancement
+- Breaking change
+- Other
 
 ## Description
 


### PR DESCRIPTION
## Type Of Change

- Documentation update

## Description

The check boxes in the PR description are regarded as task list.
Change list should not be regarded as task list.