### PR TITLE
fix: support more MIR statement (e.g. aggregate rval)

### DIFF
--- a/src/bin/core/analyze/dataflow_analyzer.rs
+++ b/src/bin/core/analyze/dataflow_analyzer.rs
@@ -220,8 +220,7 @@ impl CfgAnalyzer {
             .iter()
             .flat_map(|(block, bb_data)| {
                 let locals = locals.clone();
-                let statement_len =
-                    bb_data.statements.len() + bb_data.terminator.as_ref().map(|_| 1).unwrap_or(0);
+                let statement_len = bb_data.statements.len() + 1;
                 (0..statement_len).map(move |statement_index| {
                     (
                         AsRustc::from_rustc(rustc_middle::mir::Location {
@@ -282,26 +281,25 @@ impl CfgAnalyzer {
                         *v += 1;
                     }
                 }
-                if let Some(terminator) = &bb_data.terminator {
-                    let statement_index = bb_data.statements.len();
-                    let location: Location = AsRustc::from_rustc(rustc_middle::mir::Location {
-                        block: rustc_middle::mir::BasicBlock::from_usize(block.0),
-                        statement_index,
-                    });
-                    if let Some(current_states) = check.states_at(&location) {
-                        current_states.join(&prev_states);
-                        check.visit_terminator(terminator, location);
-                    }
-                    if let Some(current_states) = check.states_at(&location) {
-                        prev_states = current_states.clone();
-                    }
-                    if let Some(v) = check.visited(&location) {
-                        *v += 1;
-                    }
+                let terminator = &bb_data.terminator;
+                let statement_index = bb_data.statements.len();
+                let location: Location = AsRustc::from_rustc(rustc_middle::mir::Location {
+                    block: rustc_middle::mir::BasicBlock::from_usize(block.0),
+                    statement_index,
+                });
+                if let Some(current_states) = check.states_at(&location) {
+                    current_states.join(&prev_states);
+                    check.visit_terminator(terminator, location);
+                }
+                if let Some(current_states) = check.states_at(&location) {
+                    prev_states = current_states.clone();
+                }
+                if let Some(v) = check.visited(&location) {
+                    *v += 1;
+                }
 
-                    for successor in terminator.successors() {
-                        next_blocks.push_back((successor, prev_states.clone()));
-                    }
+                for successor in terminator.successors() {
+                    next_blocks.push_back((successor, prev_states.clone()));
                 }
             } else {
                 break;

--- a/src/bin/core/analyze/dataflow_analyzer.rs
+++ b/src/bin/core/analyze/dataflow_analyzer.rs
@@ -130,19 +130,21 @@ impl CfgAnalyzer {
                 if let Some(local_states) = self.states.get_mut(&location)
                     && let Some(state) = local_states.0.get_mut(&LocalId::from_rustc(
                         rustc_middle::mir::Local::from_u32(place.local.id),
-                    )) {
-                        state.clear();
-                        state.insert(LocalStateVariant::Initialized);
-                    }
+                    ))
+                {
+                    state.clear();
+                    state.insert(LocalStateVariant::Initialized);
+                }
             }
             MirStatementKind::StorageDead { local } => {
                 if let Some(local_states) = self.states.get_mut(&location)
                     && let Some(state) = local_states.0.get_mut(&LocalId::from_rustc(
                         rustc_middle::mir::Local::from_u32(local.id),
-                    )) {
-                        state.clear();
-                        state.insert(LocalStateVariant::Uninitialized);
-                    }
+                    ))
+                {
+                    state.clear();
+                    state.insert(LocalStateVariant::Uninitialized);
+                }
             }
             _ => {}
         }

--- a/src/bin/core/analyze/dataflow_analyzer.rs
+++ b/src/bin/core/analyze/dataflow_analyzer.rs
@@ -89,90 +89,109 @@ impl CfgAnalyzer {
         self.states
     }
 
+    pub fn visit_operand(&mut self, operand: &MirOperand, location: Location) {
+        if let MirOperand::Move { place, .. } = operand
+            && let Some(local_states) = self.states.get_mut(&location)
+            && let Some(state) =
+                local_states
+                    .0
+                    .get_mut(&LocalId::from_rustc(rustc_middle::mir::Local::from_u32(
+                        place.local.id,
+                    )))
+        {
+            state.clear();
+            state.insert(LocalStateVariant::Moved);
+        }
+    }
+    pub fn visit_rval(&mut self, rval: &MirRval, location: Location) {
+        match rval {
+            MirRval::Use { operand }
+            | MirRval::Repeat { operand }
+            | MirRval::Cast { operand }
+            | MirRval::UnaryOp { operand } => {
+                self.visit_operand(operand, location);
+            }
+            MirRval::BinaryOp { left, right } => {
+                self.visit_operand(left, location);
+                self.visit_operand(right, location);
+            }
+            MirRval::Aggregate { fields } => {
+                for field in fields {
+                    self.visit_operand(field, location);
+                }
+            }
+            MirRval::Ref { .. } | MirRval::Other => {}
+        }
+    }
     pub fn visit_statement(&mut self, statement: &MirStatement, location: Location) {
-        if let Some(local_states) = self.states.get_mut(&location) {
-            match statement {
-                MirStatement::Assign {
-                    target_local, rval, ..
-                } => {
-                    let mut visit_operand = |operand: &MirOperand| {
-                        if let MirOperand::Move { target_local, .. } = operand
-                            && let Some(state) =
-                                local_states.0.get_mut(&<LocalId as AsRustc>::from_rustc(
-                                    rustc_middle::mir::Local::from_u32(target_local.id),
-                                ))
-                        {
-                            state.clear();
-                            state.insert(LocalStateVariant::Moved);
-                        }
-                    };
-
-                    match rval {
-                        Some(MirRval::Operand { operand }) => {
-                            visit_operand(operand);
-                        }
-                        Some(MirRval::Aggregate { fields }) => {
-                            for field in fields.iter().flatten() {
-                                visit_operand(field);
-                            }
-                        }
-                        _ => {}
-                    }
-                    if let Some(state) = local_states.0.get_mut(&<LocalId as AsRustc>::from_rustc(
-                        rustc_middle::mir::Local::from_u32(target_local.id),
+        match &statement.kind {
+            MirStatementKind::Assign { place, rval, .. } => {
+                self.visit_rval(rval, location);
+                if let Some(local_states) = self.states.get_mut(&location)
+                    && let Some(state) = local_states.0.get_mut(&LocalId::from_rustc(
+                        rustc_middle::mir::Local::from_u32(place.local.id),
                     )) {
                         state.clear();
                         state.insert(LocalStateVariant::Initialized);
                     }
-                }
-                MirStatement::StorageDead { target_local, .. } => {
-                    if let Some(state) = local_states.0.get_mut(&<LocalId as AsRustc>::from_rustc(
-                        rustc_middle::mir::Local::from_u32(target_local.id),
+            }
+            MirStatementKind::StorageDead { local } => {
+                if let Some(local_states) = self.states.get_mut(&location)
+                    && let Some(state) = local_states.0.get_mut(&LocalId::from_rustc(
+                        rustc_middle::mir::Local::from_u32(local.id),
                     )) {
                         state.clear();
                         state.insert(LocalStateVariant::Uninitialized);
                     }
-                }
-                _ => {}
             }
+            _ => {}
         }
     }
     pub fn visit_terminator(&mut self, terminator: &MirTerminator, location: Location) {
-        if let Some(local_states) = self.states.get_mut(&location) {
-            match &terminator {
-                MirTerminator::Call {
-                    args,
-                    destination_local,
-                    ..
-                } => {
-                    for arg in args {
-                        if let Some(moved) = arg
-                            && let Some(state) =
-                                local_states.0.get_mut(&<LocalId as AsRustc>::from_rustc(
-                                    rustc_middle::mir::Local::from_u32(moved.id),
-                                ))
-                        {
-                            state.clear();
-                            state.insert(LocalStateVariant::Moved);
-                        }
-                    }
-                    if let Some(state) = local_states.0.get_mut(&<LocalId as AsRustc>::from_rustc(
-                        rustc_middle::mir::Local::from_u32(destination_local.id),
-                    )) {
-                        state.clear();
-                        state.insert(LocalStateVariant::Initialized);
-                    }
-                }
-                MirTerminator::Drop { local, .. } => {
-                    if let Some(state) = local_states.0.get_mut(&<LocalId as AsRustc>::from_rustc(
-                        rustc_middle::mir::Local::from_u32(local.id),
-                    )) {
-                        state.remove(&LocalStateVariant::Initialized);
-                        state.insert(LocalStateVariant::Dropped);
-                    }
-                }
-                _ => {}
+        match &terminator.kind {
+            MirTerminatorKind::SwitchInt { discr, .. } => {
+                self.visit_operand(discr, location);
             }
+            MirTerminatorKind::Drop { place, .. } => {
+                if let Some(local_states) = self.states.get_mut(&location)
+                    && let Some(state) = local_states.0.get_mut(&LocalId::from_rustc(
+                        rustc_middle::mir::Local::from_u32(place.local.id),
+                    ))
+                {
+                    state.remove(&LocalStateVariant::Initialized);
+                    state.insert(LocalStateVariant::Dropped);
+                }
+            }
+            MirTerminatorKind::Call {
+                func,
+                args,
+                destination,
+                ..
+            } => {
+                self.visit_operand(func, location);
+                for arg in args {
+                    self.visit_operand(arg, location);
+                }
+                if let Some(local_states) = self.states.get_mut(&location)
+                    && let Some(state) = local_states.0.get_mut(&LocalId::from_rustc(
+                        rustc_middle::mir::Local::from_u32(destination.local.id),
+                    ))
+                {
+                    state.clear();
+                    state.insert(LocalStateVariant::Initialized);
+                }
+            }
+            MirTerminatorKind::TailCall { func, args, .. } => {
+                self.visit_operand(func, location);
+                for arg in args {
+                    self.visit_operand(arg, location);
+                }
+            }
+            MirTerminatorKind::Assert { cond, .. } => {
+                self.visit_operand(cond, location);
+            }
+
+            _ => {}
         }
     }
 

--- a/src/bin/core/analyze/dataflow_analyzer.rs
+++ b/src/bin/core/analyze/dataflow_analyzer.rs
@@ -95,14 +95,28 @@ impl CfgAnalyzer {
                 MirStatement::Assign {
                     target_local, rval, ..
                 } => {
-                    if let Some(MirRval::Move { target_local, .. }) = rval
-                        && let Some(state) =
-                            local_states.0.get_mut(&<LocalId as AsRustc>::from_rustc(
-                                rustc_middle::mir::Local::from_u32(target_local.id),
-                            ))
-                    {
-                        state.clear();
-                        state.insert(LocalStateVariant::Moved);
+                    let mut visit_operand = |operand: &MirOperand| {
+                        if let MirOperand::Move { target_local, .. } = operand
+                            && let Some(state) =
+                                local_states.0.get_mut(&<LocalId as AsRustc>::from_rustc(
+                                    rustc_middle::mir::Local::from_u32(target_local.id),
+                                ))
+                        {
+                            state.clear();
+                            state.insert(LocalStateVariant::Moved);
+                        }
+                    };
+
+                    match rval {
+                        Some(MirRval::Operand { operand }) => {
+                            visit_operand(operand);
+                        }
+                        Some(MirRval::Aggregate { fields }) => {
+                            for field in fields.iter().flatten() {
+                                visit_operand(field);
+                            }
+                        }
+                        _ => {}
                     }
                     if let Some(state) = local_states.0.get_mut(&<LocalId as AsRustc>::from_rustc(
                         rustc_middle::mir::Local::from_u32(target_local.id),

--- a/src/bin/core/compiler/transform.rs
+++ b/src/bin/core/compiler/transform.rs
@@ -40,8 +40,6 @@ impl<'tcx> TyCtxt<'tcx> {
         source_info: &SourceInfo,
         location_ranges: &LocationRanges,
     ) -> IndexMap<BasicBlockId, MirBasicBlock> {
-        use rustc_middle::mir::*;
-
         body.as_rustc()
             .basic_blocks
             .iter_enumerated()
@@ -51,122 +49,22 @@ impl<'tcx> TyCtxt<'tcx> {
                     .iter()
                     .enumerate()
                     .map(|(statement_index, statement)| {
-                        let location = Location {
-                            block,
+                        Statement::from_rustc((*statement).clone()).transform(
+                            fn_id,
+                            BasicBlockId(block.as_usize()),
                             statement_index,
-                        };
-                        let range = location_ranges.get(&AsRustc::from_rustc(location)).copied();
-                        let operand_transform = |operand: &Operand| match operand {
-                            Operand::Copy(p) => {
-                                let local = p.local;
-                                range.map(|range| MirOperand::Copy {
-                                    target_local: FnLocal::new(local.as_u32(), fn_id.as_u32()),
-                                    range,
-                                })
-                            }
-                            Operand::Move(p) => {
-                                let local = p.local;
-                                range.map(|range| MirOperand::Move {
-                                    target_local: FnLocal::new(local.as_u32(), fn_id.as_u32()),
-                                    range,
-                                })
-                            }
-                            _ => Some(MirOperand::Other),
-                        };
-                        match &statement.kind {
-                            StatementKind::StorageLive(local) => MirStatement::StorageLive {
-                                target_local: FnLocal::new(local.as_u32(), fn_id.as_u32()),
-                                range,
-                            },
-                            StatementKind::StorageDead(local) => MirStatement::StorageDead {
-                                target_local: FnLocal::new(local.as_u32(), fn_id.as_u32()),
-                                range,
-                            },
-                            StatementKind::Assign(v) => {
-                                let (place, rval) = &**v;
-                                let target_local_index = place.local.as_u32();
-                                let rv = match rval {
-                                    Rvalue::Use(operand) => operand_transform(operand)
-                                        .map(|operand| MirRval::Operand { operand }),
-                                    Rvalue::Ref(_region, kind, place) => {
-                                        let mutable = matches!(kind, BorrowKind::Mut { .. });
-                                        let local = place.local;
-                                        let outlive = None;
-                                        range.map(|range| MirRval::Borrow {
-                                            target_local: FnLocal::new(
-                                                local.as_u32(),
-                                                fn_id.as_u32(),
-                                            ),
-                                            range,
-                                            mutable,
-                                            outlive,
-                                        })
-                                    }
-                                    Rvalue::Aggregate(_, fields) => Some(MirRval::Aggregate {
-                                        fields: fields.iter().map(operand_transform).collect(),
-                                    }),
-                                    _ => None,
-                                };
-                                MirStatement::Assign {
-                                    target_local: FnLocal::new(target_local_index, fn_id.as_u32()),
-                                    range,
-                                    rval: rv,
-                                }
-                            }
-                            _ => MirStatement::Other { range },
-                        }
+                            location_ranges,
+                        )
                     })
                     .collect();
                 let terminator = bb_data.terminator.as_ref().map(|terminator| {
-                    let location = Location {
-                        block,
-                        statement_index: bb_data.statements.len(),
-                    };
-                    let range = location_ranges.get(&AsRustc::from_rustc(location)).copied();
-                    let successors = terminator
-                        .successors()
-                        .map(|v| BasicBlockId(v.as_usize()))
-                        .collect();
-                    match &terminator.kind {
-                        TerminatorKind::Drop { place, .. } => MirTerminator::Drop {
-                            local: FnLocal::new(place.local.as_u32(), fn_id.as_u32()),
-                            range,
-                            successors,
-                        },
-                        TerminatorKind::Call {
-                            args,
-                            destination,
-                            fn_span,
-                            ..
-                        } => {
-                            let fn_span = range_from_span(
-                                source_info.source(),
-                                AsRustc::from_rustc(*fn_span),
-                                source_info.offset,
-                            );
-                            let args: Vec<_> = args
-                                .iter()
-                                .map(|v| {
-                                    if let Operand::Move(p) = &v.node {
-                                        p.as_local()
-                                            .map(|v| FnLocal::new(v.as_u32(), fn_id.as_u32()))
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect();
-                            MirTerminator::Call {
-                                args,
-                                destination_local: FnLocal::new(
-                                    destination.local.as_u32(),
-                                    fn_id.as_u32(),
-                                ),
-                                fn_span,
-                                successors,
-                            }
-                        }
-                        _ => MirTerminator::Other { range, successors },
-                    }
+                    Terminator::from_rustc(terminator.clone()).transform(
+                        fn_id,
+                        BasicBlockId(block.as_usize()),
+                        bb_data.statements.len(),
+                        source_info,
+                        location_ranges,
+                    )
                 });
                 (
                     BasicBlockId(block.as_usize()),
@@ -372,5 +270,283 @@ impl BorrowMap {
     }
     pub fn local_map(&self) -> &HashMap<LocalId, HashSet<Borrow>> {
         &self.local_map
+    }
+}
+
+impl_as_rustc!(
+    #[derive(Clone, Hash, Debug)]
+    Place<'tcx>,
+    rustc_middle::mir::Place<'tcx>,
+);
+impl Place<'_> {
+    pub fn transform(&self, fn_id: DefId) -> MirPlace {
+        let place = &self.as_rustc();
+        use rustc_middle::mir::ProjectionElem;
+        let local = FnLocal::new(place.local.as_u32(), fn_id.as_u32());
+        let projection = place
+            .projection
+            .iter()
+            .map(|e| match e {
+                ProjectionElem::Deref => MirProjectionElem::Deref,
+                ProjectionElem::Field(idx, _ty) => MirProjectionElem::Field {
+                    index: idx.as_usize(),
+                },
+                ProjectionElem::Index(local) => MirProjectionElem::Index {
+                    local: FnLocal::new(local.as_u32(), fn_id.as_u32()),
+                },
+                _ => MirProjectionElem::Other,
+            })
+            .collect();
+        MirPlace { local, projection }
+    }
+}
+
+impl_as_rustc!(
+    #[derive(Clone, Hash, Debug)]
+    Operand<'tcx>,
+    rustc_middle::mir::Operand<'tcx>,
+);
+impl Operand<'_> {
+    pub fn transform(&self, fn_id: DefId) -> MirOperand {
+        use rustc_middle::mir::Operand;
+        match &self.as_rustc() {
+            Operand::Copy(place) => MirOperand::Copy {
+                place: Place::from_rustc(*place).transform(fn_id),
+            },
+            Operand::Move(place) => MirOperand::Move {
+                place: Place::from_rustc(*place).transform(fn_id),
+            },
+            _ => MirOperand::Other,
+        }
+    }
+}
+
+impl_as_rustc!(
+    #[derive(Clone, Hash, Debug)]
+    Rvalue<'tcx>,
+    rustc_middle::mir::Rvalue<'tcx>,
+);
+impl Rvalue<'_> {
+    pub fn transform(&self, fn_id: DefId) -> MirRval {
+        use rustc_middle::mir::Rvalue;
+        match &self.as_rustc() {
+            Rvalue::Use(operand) => {
+                let operand = Operand::from_rustc(operand.clone()).transform(fn_id);
+                MirRval::Use { operand }
+            }
+            Rvalue::Repeat(operand, _) => {
+                let operand = Operand::from_rustc(operand.clone()).transform(fn_id);
+                MirRval::Repeat { operand }
+            }
+            Rvalue::Ref(_region, kind, place) => {
+                let place = Place::from_rustc(*place).transform(fn_id);
+                let mutable = kind.mutability().is_mut();
+                MirRval::Ref { place, mutable }
+            }
+            Rvalue::Cast(_kind, operand, _ty) => {
+                let operand = Operand::from_rustc(operand.clone()).transform(fn_id);
+                MirRval::Cast { operand }
+            }
+            Rvalue::BinaryOp(_op, boxed) => {
+                let left = Operand::from_rustc((**boxed).0.clone()).transform(fn_id);
+                let right = Operand::from_rustc((**boxed).1.clone()).transform(fn_id);
+                MirRval::BinaryOp { left, right }
+            }
+            Rvalue::UnaryOp(_op, operand) => {
+                let operand = Operand::from_rustc(operand.clone()).transform(fn_id);
+                MirRval::UnaryOp { operand }
+            }
+            Rvalue::Aggregate(_kind, operands) => {
+                let fields = operands
+                    .iter()
+                    .map(|v| Operand::from_rustc(v.clone()).transform(fn_id))
+                    .collect();
+                MirRval::Aggregate { fields }
+            }
+            _ => MirRval::Other,
+        }
+    }
+}
+
+impl_as_rustc!(
+    #[derive(Clone, Debug)]
+    Statement<'tcx>,
+    rustc_middle::mir::Statement<'tcx>,
+);
+impl Statement<'_> {
+    pub fn transform(
+        &self,
+        fn_id: DefId,
+        block: BasicBlockId,
+        statement_index: usize,
+        location_ranges: &LocationRanges,
+    ) -> MirStatement {
+        use rustc_middle::mir::StatementKind;
+        let location = rustc_middle::mir::Location {
+            block: rustc_middle::mir::BasicBlock::from_usize(block.0),
+            statement_index,
+        };
+        let range = location_ranges
+            .get(&Location::from_rustc(location))
+            .copied();
+        match &self.as_rustc().kind {
+            StatementKind::Assign(boxed) => {
+                let place = Place::from_rustc((**boxed).0).transform(fn_id);
+                let rval = Rvalue::from_rustc((**boxed).1.clone()).transform(fn_id);
+                let kind = MirStatementKind::Assign { place, rval };
+                MirStatement { kind, range }
+            }
+            StatementKind::StorageLive(local) => MirStatement {
+                kind: MirStatementKind::StorageLive {
+                    local: FnLocal::new(local.as_u32(), fn_id.as_u32()),
+                },
+                range,
+            },
+            StatementKind::StorageDead(local) => MirStatement {
+                kind: MirStatementKind::StorageDead {
+                    local: FnLocal::new(local.as_u32(), fn_id.as_u32()),
+                },
+                range,
+            },
+            StatementKind::Nop => MirStatement {
+                kind: MirStatementKind::Nop,
+                range,
+            },
+            _ => MirStatement {
+                kind: MirStatementKind::Other,
+                range,
+            },
+        }
+    }
+}
+
+impl_as_rustc!(
+    #[derive(Clone, Debug)]
+    Terminator<'tcx>,
+    rustc_middle::mir::Terminator<'tcx>,
+);
+impl Terminator<'_> {
+    pub fn transform(
+        &self,
+        fn_id: DefId,
+        block: BasicBlockId,
+        statement_index: usize,
+        source_info: &SourceInfo,
+        location_ranges: &LocationRanges,
+    ) -> MirTerminator {
+        use rustc_middle::mir::TerminatorKind;
+        let location = rustc_middle::mir::Location {
+            block: rustc_middle::mir::BasicBlock::from_usize(block.0),
+            statement_index,
+        };
+        let range = location_ranges
+            .get(&Location::from_rustc(location))
+            .copied();
+        match &self.as_rustc().kind {
+            TerminatorKind::Goto { target } => MirTerminator {
+                kind: MirTerminatorKind::Goto {
+                    target: BasicBlockId(target.as_usize()),
+                },
+                range,
+            },
+            TerminatorKind::SwitchInt { discr, targets } => {
+                let discr = Operand::from_rustc(discr.clone()).transform(fn_id);
+                let targets = targets
+                    .all_targets()
+                    .iter()
+                    .map(|v| BasicBlockId(v.as_usize()))
+                    .collect();
+                MirTerminator {
+                    kind: MirTerminatorKind::SwitchInt { discr, targets },
+                    range,
+                }
+            }
+            TerminatorKind::Return => MirTerminator {
+                kind: MirTerminatorKind::Return,
+                range,
+            },
+            TerminatorKind::Unreachable => MirTerminator {
+                kind: MirTerminatorKind::Unreachable,
+                range,
+            },
+            TerminatorKind::Drop { place, target, .. } => {
+                let kind = MirTerminatorKind::Drop {
+                    place: Place::from_rustc(*place).transform(fn_id),
+                    target: BasicBlockId(target.as_usize()),
+                };
+                MirTerminator { kind, range }
+            }
+            TerminatorKind::Call {
+                func,
+                args,
+                destination,
+                target,
+                fn_span,
+                ..
+            } => {
+                let func = Operand::from_rustc(func.clone()).transform(fn_id);
+                let args = args
+                    .iter()
+                    .map(|v| Operand::from_rustc(v.node.clone()).transform(fn_id))
+                    .collect();
+                let destination = Place::from_rustc(*destination).transform(fn_id);
+                let fn_range = range_from_span(
+                    source_info.source(),
+                    Span::from_rustc(*fn_span),
+                    source_info.offset,
+                );
+                let kind = MirTerminatorKind::Call {
+                    func,
+                    args,
+                    destination,
+                    target: target.map(|v| BasicBlockId(v.as_usize())),
+                    fn_range,
+                };
+                MirTerminator { kind, range }
+            }
+            TerminatorKind::TailCall {
+                func,
+                args,
+                fn_span,
+            } => {
+                let func = Operand::from_rustc(func.clone()).transform(fn_id);
+                let args = args
+                    .iter()
+                    .map(|v| Operand::from_rustc(v.node.clone()).transform(fn_id))
+                    .collect();
+                let fn_range = range_from_span(
+                    source_info.source(),
+                    Span::from_rustc(*fn_span),
+                    source_info.offset,
+                );
+                let kind = MirTerminatorKind::TailCall {
+                    func,
+                    args,
+                    fn_range,
+                };
+                MirTerminator { kind, range }
+            }
+            TerminatorKind::Assert { cond, target, .. } => {
+                let cond = Operand::from_rustc(cond.clone()).transform(fn_id);
+                MirTerminator {
+                    kind: MirTerminatorKind::Assert {
+                        cond,
+                        target: BasicBlockId(target.as_usize()),
+                    },
+                    range,
+                }
+            }
+            _ => {
+                let successors = self
+                    .as_rustc()
+                    .successors()
+                    .map(|v| BasicBlockId(v.as_usize()))
+                    .collect();
+                MirTerminator {
+                    kind: MirTerminatorKind::Other { successors },
+                    range,
+                }
+            }
+        }
     }
 }

--- a/src/bin/core/compiler/transform.rs
+++ b/src/bin/core/compiler/transform.rs
@@ -56,6 +56,23 @@ impl<'tcx> TyCtxt<'tcx> {
                             statement_index,
                         };
                         let range = location_ranges.get(&AsRustc::from_rustc(location)).copied();
+                        let operand_transform = |operand: &Operand| match operand {
+                            Operand::Copy(p) => {
+                                let local = p.local;
+                                range.map(|range| MirOperand::Copy {
+                                    target_local: FnLocal::new(local.as_u32(), fn_id.as_u32()),
+                                    range,
+                                })
+                            }
+                            Operand::Move(p) => {
+                                let local = p.local;
+                                range.map(|range| MirOperand::Move {
+                                    target_local: FnLocal::new(local.as_u32(), fn_id.as_u32()),
+                                    range,
+                                })
+                            }
+                            _ => Some(MirOperand::Other),
+                        };
                         match &statement.kind {
                             StatementKind::StorageLive(local) => MirStatement::StorageLive {
                                 target_local: FnLocal::new(local.as_u32(), fn_id.as_u32()),
@@ -69,16 +86,8 @@ impl<'tcx> TyCtxt<'tcx> {
                                 let (place, rval) = &**v;
                                 let target_local_index = place.local.as_u32();
                                 let rv = match rval {
-                                    Rvalue::Use(Operand::Move(p)) => {
-                                        let local = p.local;
-                                        range.map(|range| MirRval::Move {
-                                            target_local: FnLocal::new(
-                                                local.as_u32(),
-                                                fn_id.as_u32(),
-                                            ),
-                                            range,
-                                        })
-                                    }
+                                    Rvalue::Use(operand) => operand_transform(operand)
+                                        .map(|operand| MirRval::Operand { operand }),
                                     Rvalue::Ref(_region, kind, place) => {
                                         let mutable = matches!(kind, BorrowKind::Mut { .. });
                                         let local = place.local;
@@ -93,6 +102,9 @@ impl<'tcx> TyCtxt<'tcx> {
                                             outlive,
                                         })
                                     }
+                                    Rvalue::Aggregate(_, fields) => Some(MirRval::Aggregate {
+                                        fields: fields.iter().map(operand_transform).collect(),
+                                    }),
                                     _ => None,
                                 };
                                 MirStatement::Assign {

--- a/src/bin/core/compiler/transform.rs
+++ b/src/bin/core/compiler/transform.rs
@@ -57,15 +57,13 @@ impl<'tcx> TyCtxt<'tcx> {
                         )
                     })
                     .collect();
-                let terminator = bb_data.terminator.as_ref().map(|terminator| {
-                    Terminator::from_rustc(terminator.clone()).transform(
-                        fn_id,
-                        BasicBlockId(block.as_usize()),
-                        bb_data.statements.len(),
-                        source_info,
-                        location_ranges,
-                    )
-                });
+                let terminator = Terminator::from_rustc(bb_data.terminator().clone()).transform(
+                    fn_id,
+                    BasicBlockId(block.as_usize()),
+                    bb_data.statements.len(),
+                    source_info,
+                    location_ranges,
+                );
                 (
                     BasicBlockId(block.as_usize()),
                     MirBasicBlock {
@@ -145,7 +143,7 @@ impl LocationRanges {
         let mut map = HashMap::new();
         for (block, bb_data) in body.as_rustc().basic_blocks.iter_enumerated() {
             let stmt_count = bb_data.statements.len();
-            let total = stmt_count + bb_data.terminator.as_ref().map(|_| 1).unwrap_or(0);
+            let total = stmt_count + 1;
             for statement_index in 0..total {
                 let location = rustc_middle::mir::Location {
                     block,
@@ -175,11 +173,11 @@ impl LocationRanges {
                         _ => false,
                     }
                 } else {
-                    match bb_data.terminator.as_ref().map(|t| &t.kind) {
-                        Some(TerminatorKind::Drop { place, .. }) => {
+                    match &bb_data.terminator().kind {
+                        TerminatorKind::Drop { place, .. } => {
                             user_locals.contains_key(&AsRustc::from_rustc(place.local))
                         }
-                        Some(TerminatorKind::Call { .. }) => {
+                        TerminatorKind::Call { .. } => {
                             // A return value of method call can be important if it is assigned to
                             // a temporary variable, so we always visualize them.
                             true

--- a/src/lsp/decoration.rs
+++ b/src/lsp/decoration.rs
@@ -670,7 +670,9 @@ impl CalcDecos {
     }
 
     pub fn visit_operand(&mut self, operand: &MirOperand, range: Range) {
-        if let MirOperand::Move { place } = operand {
+        if let MirOperand::Move { place } = operand
+            && self.locals.contains(&place.local)
+        {
             self.decorations.push(Deco::Move {
                 local: place.local,
                 range,

--- a/src/lsp/decoration.rs
+++ b/src/lsp/decoration.rs
@@ -311,6 +311,7 @@ impl CursorRequest {
 enum SelectReason {
     Var,
     Move,
+    Drop,
     Borrow,
     Call,
 }
@@ -333,32 +334,31 @@ impl SelectLocal {
         if !self.candidate_local_decls.contains(&local) {
             return;
         }
-        if range.from() <= self.pos
-            && self.pos <= range.until()
-            && let Some((old_reason, _, old_range)) = self.selected
-        {
-            match (old_reason, reason) {
-                (_, SelectReason::Var) => {
-                    if range.size() < old_range.size() {
-                        self.selected = Some((reason, local, range));
+        if range.from() <= self.pos && self.pos <= range.until() {
+            if let Some((old_reason, _, old_range)) = self.selected {
+                match (old_reason, reason) {
+                    (_, SelectReason::Var) => {
+                        if range.size() < old_range.size() {
+                            self.selected = Some((reason, local, range));
+                        }
                     }
-                }
-                (SelectReason::Var, _) => {}
-                (_, SelectReason::Move) | (_, SelectReason::Borrow) => {
-                    if range.size() < old_range.size() {
-                        self.selected = Some((reason, local, range));
+                    (SelectReason::Var, _) => {}
+                    (_, SelectReason::Move) | (_, SelectReason::Borrow) => {
+                        if range.size() < old_range.size() {
+                            self.selected = Some((reason, local, range));
+                        }
                     }
-                }
-                (SelectReason::Call, SelectReason::Call) => {
-                    // TODO: select narrower when callee is method
-                    if old_range.size() < range.size() {
-                        self.selected = Some((reason, local, range));
+                    (SelectReason::Call, SelectReason::Call) => {
+                        // TODO: select narrower when callee is method
+                        if old_range.size() < range.size() {
+                            self.selected = Some((reason, local, range));
+                        }
                     }
+                    _ => {}
                 }
-                _ => {}
+            } else {
+                self.selected = Some((reason, local, range));
             }
-        } else {
-            self.selected = Some((reason, local, range));
         }
     }
 
@@ -439,11 +439,13 @@ impl utils::MirVisitor for SelectLocal {
                 MirTerminatorKind::Assert { cond, .. } => {
                     self.select_operand(cond, range);
                 }
+                MirTerminatorKind::Drop { place, .. } => {
+                    self.select(SelectReason::Drop, place.local, range);
+                }
                 MirTerminatorKind::Goto { .. }
                 | MirTerminatorKind::SwitchInt { .. }
                 | MirTerminatorKind::Return
                 | MirTerminatorKind::Unreachable
-                | MirTerminatorKind::Drop { .. }
                 | MirTerminatorKind::Other { .. } => {}
             }
         }

--- a/src/lsp/decoration.rs
+++ b/src/lsp/decoration.rs
@@ -365,6 +365,12 @@ impl SelectLocal {
     pub fn selected(&self) -> Option<FnLocal> {
         self.selected.map(|v| v.1)
     }
+
+    pub fn select_operand(&mut self, operand: &MirOperand, range: Range) {
+        if let MirOperand::Move { place } = operand {
+            self.select(SelectReason::Move, place.local, range);
+        }
+    }
 }
 impl utils::MirVisitor for SelectLocal {
     fn visit_decl(&mut self, decl: &MirDecl) {
@@ -381,48 +387,65 @@ impl utils::MirVisitor for SelectLocal {
         }
     }
     fn visit_stmt(&mut self, stmt: &MirStatement) {
-        if let MirStatement::Assign { rval, .. } = stmt {
+        if let Some(range) = stmt.range
+            && let MirStatementKind::Assign { rval, .. } = &stmt.kind
+        {
             match rval {
-                Some(MirRval::Operand {
-                    operand:
-                        MirOperand::Move {
-                            target_local,
-                            range,
-                        },
-                }) => {
-                    self.select(SelectReason::Move, *target_local, *range);
+                MirRval::Use { operand }
+                | MirRval::Repeat { operand }
+                | MirRval::Cast { operand }
+                | MirRval::UnaryOp { operand } => {
+                    self.select_operand(operand, range);
                 }
-                Some(MirRval::Borrow {
-                    target_local,
-                    range,
-                    ..
-                }) => {
-                    self.select(SelectReason::Borrow, *target_local, *range);
+                MirRval::BinaryOp { left, right } => {
+                    self.select_operand(left, range);
+                    self.select_operand(right, range);
                 }
-                Some(MirRval::Aggregate { fields }) => {
+                MirRval::Ref { place, .. } => {
+                    self.select(SelectReason::Borrow, place.local, range);
+                }
+                MirRval::Aggregate { fields } => {
                     for field in fields {
-                        if let Some(MirOperand::Move {
-                            target_local,
-                            range,
-                        }) = field
-                        {
-                            self.select(SelectReason::Move, *target_local, *range);
-                        }
+                        self.select_operand(field, range);
                     }
                 }
-                _ => {}
+                MirRval::Other => {}
             }
         }
     }
     fn visit_term(&mut self, term: &MirTerminator) {
-        if let MirTerminator::Call {
-            destination_local,
-            fn_span,
-            ..
-        } = term
-            && let Some(fn_span) = fn_span
-        {
-            self.select(SelectReason::Call, *destination_local, *fn_span);
+        if let Some(range) = term.range {
+            match &term.kind {
+                MirTerminatorKind::Call {
+                    args,
+                    destination,
+                    fn_range,
+                    ..
+                } => {
+                    for arg in args {
+                        self.select_operand(arg, range);
+                    }
+                    if let Some(fn_range) = fn_range {
+                        self.select(SelectReason::Call, destination.local, *fn_range);
+                    }
+                }
+                MirTerminatorKind::TailCall { args, fn_range, .. } => {
+                    if let Some(fn_range) = fn_range {
+                        for arg in args {
+                            self.select_operand(arg, *fn_range);
+                        }
+                    }
+                }
+                MirTerminatorKind::Assert { cond, .. } => {
+                    self.select_operand(cond, range);
+                }
+                MirTerminatorKind::Goto { .. }
+                | MirTerminatorKind::SwitchInt { .. }
+                | MirTerminatorKind::Return
+                | MirTerminatorKind::Unreachable
+                | MirTerminatorKind::Drop { .. }
+                | MirTerminatorKind::Other { .. } => {}
+            }
         }
     }
 }
@@ -645,6 +668,46 @@ impl CalcDecos {
     pub fn decorations(self) -> Vec<Deco> {
         self.decorations
     }
+
+    pub fn visit_operand(&mut self, operand: &MirOperand, range: Range) {
+        if let MirOperand::Move { place } = operand {
+            self.decorations.push(Deco::Move {
+                local: place.local,
+                range,
+                hover_text: "variable moved".to_string(),
+                overlapped: false,
+            });
+        }
+    }
+    pub fn calc_call(&mut self, destination: &MirPlace, fn_span: Range) {
+        for deco in &self.decorations {
+            if let Deco::Call { range, .. } = deco
+                && utils::is_super_range(fn_span, *range)
+            {
+                return;
+            }
+        }
+        let mut i = 0;
+        while i < self.decorations.len() {
+            let range = match &self.decorations[i] {
+                Deco::Call { range, .. } => Some(range),
+                _ => None,
+            };
+            if let Some(range) = range
+                && utils::is_super_range(*range, fn_span)
+            {
+                self.decorations.remove(i);
+                continue;
+            }
+            i += 1;
+        }
+        self.decorations.push(Deco::Call {
+            local: destination.local,
+            range: fn_span,
+            hover_text: "function call".to_string(),
+            overlapped: false,
+        });
+    }
 }
 impl utils::MirVisitor for CalcDecos {
     fn visit_decl(&mut self, decl: &MirDecl) {
@@ -778,98 +841,83 @@ impl utils::MirVisitor for CalcDecos {
     }
 
     fn visit_stmt(&mut self, stmt: &MirStatement) {
-        if let MirStatement::Assign { rval, .. } = stmt {
-            let mut push_operand = |operand: &MirOperand| {
-                if let MirOperand::Move {
-                    target_local,
-                    range,
-                } = operand
-                    && self.locals.contains(target_local)
-                {
-                    self.decorations.push(Deco::Move {
-                        local: *target_local,
-                        range: *range,
-                        hover_text: "variable moved".to_string(),
-                        overlapped: false,
-                    });
-                }
-            };
+        if let Some(range) = stmt.range
+            && let MirStatementKind::Assign { rval, .. } = &stmt.kind
+        {
             match rval {
-                Some(MirRval::Operand { operand }) => {
-                    push_operand(operand);
+                MirRval::Use { operand }
+                | MirRval::Repeat { operand }
+                | MirRval::Cast { operand }
+                | MirRval::UnaryOp { operand } => {
+                    self.visit_operand(operand, range);
                 }
-                Some(MirRval::Borrow {
-                    target_local,
-                    range,
-                    mutable,
-                    ..
-                }) => {
-                    if self.locals.contains(target_local) {
+                MirRval::BinaryOp { left, right } => {
+                    self.visit_operand(left, range);
+                    self.visit_operand(right, range);
+                }
+                MirRval::Ref { place, mutable } => {
+                    if self.locals.contains(&place.local) {
                         if *mutable {
                             self.decorations.push(Deco::MutBorrow {
-                                local: *target_local,
-                                range: *range,
+                                local: place.local,
+                                range,
                                 hover_text: "mutable borrow".to_string(),
                                 overlapped: false,
                             });
                         } else {
                             self.decorations.push(Deco::ImmBorrow {
-                                local: *target_local,
-                                range: *range,
+                                local: place.local,
+                                range,
                                 hover_text: "immutable borrow".to_string(),
                                 overlapped: false,
                             });
                         }
                     }
                 }
-                Some(MirRval::Aggregate { fields }) => {
-                    for field in fields.iter().flatten() {
-                        push_operand(field);
+                MirRval::Aggregate { fields } => {
+                    for field in fields {
+                        self.visit_operand(field, range);
                     }
                 }
-                _ => {}
+                MirRval::Other => {}
             }
         }
     }
 
     fn visit_term(&mut self, term: &MirTerminator) {
-        if let MirTerminator::Call {
-            destination_local,
-            fn_span,
-            ..
-        } = term
-            && self.locals.contains(destination_local)
-        {
-            let mut i = 0;
-            for deco in &self.decorations {
-                if let Deco::Call { range, .. } = deco
-                    && let Some(fn_span) = fn_span
-                    && utils::is_super_range(*fn_span, *range)
-                {
-                    return;
+        if let Some(range) = term.range {
+            match &term.kind {
+                MirTerminatorKind::Call {
+                    args,
+                    destination,
+                    fn_range,
+                    ..
+                } => {
+                    for arg in args {
+                        self.visit_operand(arg, range);
+                    }
+                    if let Some(fn_range) = fn_range
+                        && self.locals.contains(&destination.local)
+                    {
+                        self.calc_call(destination, *fn_range)
+                    }
                 }
-            }
-            while i < self.decorations.len() {
-                let range = match &self.decorations[i] {
-                    Deco::Call { range, .. } => Some(range),
-                    _ => None,
-                };
-                if let Some(range) = range
-                    && let Some(fn_span) = fn_span
-                    && utils::is_super_range(*range, *fn_span)
-                {
-                    self.decorations.remove(i);
-                    continue;
+                MirTerminatorKind::TailCall { args, fn_range, .. } => {
+                    if let Some(fn_range) = fn_range {
+                        for arg in args {
+                            self.visit_operand(arg, *fn_range);
+                        }
+                    }
                 }
-                i += 1;
-            }
-            if let Some(fn_span) = fn_span {
-                self.decorations.push(Deco::Call {
-                    local: *destination_local,
-                    range: *fn_span,
-                    hover_text: "function call".to_string(),
-                    overlapped: false,
-                });
+                MirTerminatorKind::Assert { cond, .. } => {
+                    self.visit_operand(cond, range);
+                }
+                MirTerminatorKind::Goto { .. }
+                | MirTerminatorKind::SwitchInt { .. }
+                | MirTerminatorKind::Return
+                | MirTerminatorKind::Unreachable
+                | MirTerminatorKind::Drop { .. }
+                | MirTerminatorKind::Other { .. } => {}
             }
         }
     }

--- a/src/lsp/decoration.rs
+++ b/src/lsp/decoration.rs
@@ -333,31 +333,32 @@ impl SelectLocal {
         if !self.candidate_local_decls.contains(&local) {
             return;
         }
-        if range.from() <= self.pos && self.pos <= range.until() {
-            if let Some((old_reason, _, old_range)) = self.selected {
-                match (old_reason, reason) {
-                    (_, SelectReason::Var) => {
-                        if range.size() < old_range.size() {
-                            self.selected = Some((reason, local, range));
-                        }
+        if range.from() <= self.pos
+            && self.pos <= range.until()
+            && let Some((old_reason, _, old_range)) = self.selected
+        {
+            match (old_reason, reason) {
+                (_, SelectReason::Var) => {
+                    if range.size() < old_range.size() {
+                        self.selected = Some((reason, local, range));
                     }
-                    (SelectReason::Var, _) => {}
-                    (_, SelectReason::Move) | (_, SelectReason::Borrow) => {
-                        if range.size() < old_range.size() {
-                            self.selected = Some((reason, local, range));
-                        }
-                    }
-                    (SelectReason::Call, SelectReason::Call) => {
-                        // TODO: select narrower when callee is method
-                        if old_range.size() < range.size() {
-                            self.selected = Some((reason, local, range));
-                        }
-                    }
-                    _ => {}
                 }
-            } else {
-                self.selected = Some((reason, local, range));
+                (SelectReason::Var, _) => {}
+                (_, SelectReason::Move) | (_, SelectReason::Borrow) => {
+                    if range.size() < old_range.size() {
+                        self.selected = Some((reason, local, range));
+                    }
+                }
+                (SelectReason::Call, SelectReason::Call) => {
+                    // TODO: select narrower when callee is method
+                    if old_range.size() < range.size() {
+                        self.selected = Some((reason, local, range));
+                    }
+                }
+                _ => {}
             }
+        } else {
+            self.selected = Some((reason, local, range));
         }
     }
 
@@ -382,9 +383,12 @@ impl utils::MirVisitor for SelectLocal {
     fn visit_stmt(&mut self, stmt: &MirStatement) {
         if let MirStatement::Assign { rval, .. } = stmt {
             match rval {
-                Some(MirRval::Move {
-                    target_local,
-                    range,
+                Some(MirRval::Operand {
+                    operand:
+                        MirOperand::Move {
+                            target_local,
+                            range,
+                        },
                 }) => {
                     self.select(SelectReason::Move, *target_local, *range);
                 }
@@ -394,6 +398,17 @@ impl utils::MirVisitor for SelectLocal {
                     ..
                 }) => {
                     self.select(SelectReason::Borrow, *target_local, *range);
+                }
+                Some(MirRval::Aggregate { fields }) => {
+                    for field in fields {
+                        if let Some(MirOperand::Move {
+                            target_local,
+                            range,
+                        }) = field
+                        {
+                            self.select(SelectReason::Move, *target_local, *range);
+                        }
+                    }
                 }
                 _ => {}
             }
@@ -764,19 +779,24 @@ impl utils::MirVisitor for CalcDecos {
 
     fn visit_stmt(&mut self, stmt: &MirStatement) {
         if let MirStatement::Assign { rval, .. } = stmt {
-            match rval {
-                Some(MirRval::Move {
+            let mut push_operand = |operand: &MirOperand| {
+                if let MirOperand::Move {
                     target_local,
                     range,
-                }) => {
-                    if self.locals.contains(target_local) {
-                        self.decorations.push(Deco::Move {
-                            local: *target_local,
-                            range: *range,
-                            hover_text: "variable moved".to_string(),
-                            overlapped: false,
-                        });
-                    }
+                } = operand
+                    && self.locals.contains(target_local)
+                {
+                    self.decorations.push(Deco::Move {
+                        local: *target_local,
+                        range: *range,
+                        hover_text: "variable moved".to_string(),
+                        overlapped: false,
+                    });
+                }
+            };
+            match rval {
+                Some(MirRval::Operand { operand }) => {
+                    push_operand(operand);
                 }
                 Some(MirRval::Borrow {
                     target_local,
@@ -800,6 +820,11 @@ impl utils::MirVisitor for CalcDecos {
                                 overlapped: false,
                             });
                         }
+                    }
+                }
+                Some(MirRval::Aggregate { fields }) => {
+                    for field in fields.iter().flatten() {
+                        push_operand(field);
                     }
                 }
                 _ => {}

--- a/src/models.rs
+++ b/src/models.rs
@@ -195,94 +195,119 @@ impl Crate {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum MirProjectionElem {
+    Deref,
+    Field { index: usize },
+    Index { local: FnLocal },
+    Other,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct MirPlace {
+    pub local: FnLocal,
+    pub projection: Vec<MirProjectionElem>,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum MirOperand {
-    Copy { target_local: FnLocal, range: Range },
-    Move { target_local: FnLocal, range: Range },
+    Copy { place: MirPlace },
+    Move { place: MirPlace },
+    // TODO: Constant, RuntimeChecks
     Other,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum MirRval {
-    Operand {
-        operand: MirOperand,
-    },
-    Borrow {
-        target_local: FnLocal,
-        range: Range,
-        mutable: bool,
-        outlive: Option<Range>,
-    },
-    Aggregate {
-        fields: Vec<Option<MirOperand>>,
-    },
+    Use { operand: MirOperand },
+    Repeat { operand: MirOperand },
+    Ref { place: MirPlace, mutable: bool },
+    Cast { operand: MirOperand },
+    BinaryOp { left: MirOperand, right: MirOperand },
+    UnaryOp { operand: MirOperand },
+    Aggregate { fields: Vec<MirOperand> },
+    // TODO: ThreadLocalRef, RawPtr, Discriminant, CopyForDeref, WrapUnsafeBinder, Reborrow
+    Other,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub struct MirStatement {
+    #[serde(flatten)]
+    pub kind: MirStatementKind,
+    pub range: Option<Range>,
+}
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum MirStatementKind {
+    Assign { place: MirPlace, rval: MirRval },
+    StorageLive { local: FnLocal },
+    StorageDead { local: FnLocal },
+    Nop,
+    // TODO: FakeRead, SetDiscriminant, PlaceMention, AscribeUserType, Coverage, ConstEvalCounter,
+    // BackwardIncompatibleDropHint
+    Other,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct MirTerminator {
+    #[serde(flatten)]
+    pub kind: MirTerminatorKind,
+    pub range: Option<Range>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "snake_case", tag = "type")]
-pub enum MirStatement {
-    StorageLive {
-        target_local: FnLocal,
-        range: Option<Range>,
+pub enum MirTerminatorKind {
+    Goto {
+        target: BasicBlockId,
     },
-    StorageDead {
-        target_local: FnLocal,
-        range: Option<Range>,
+    SwitchInt {
+        discr: MirOperand,
+        targets: Vec<BasicBlockId>,
     },
-    Assign {
-        target_local: FnLocal,
-        range: Option<Range>,
-        rval: Option<MirRval>,
-    },
-    Other {
-        range: Option<Range>,
-    },
-}
-impl MirStatement {
-    pub fn range(&self) -> Option<Range> {
-        match self {
-            Self::StorageLive { range, .. } => *range,
-            Self::StorageDead { range, .. } => *range,
-            Self::Assign { range, .. } => *range,
-            Self::Other { range } => *range,
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "snake_case", tag = "type")]
-pub enum MirTerminator {
+    Return,
+    Unreachable,
     Drop {
-        local: FnLocal,
-        range: Option<Range>,
-        successors: Vec<BasicBlockId>,
+        place: MirPlace,
+        target: BasicBlockId,
     },
     Call {
-        args: Vec<Option<FnLocal>>,
-        destination_local: FnLocal,
-        fn_span: Option<Range>,
-        successors: Vec<BasicBlockId>,
+        func: MirOperand,
+        args: Vec<MirOperand>,
+        destination: MirPlace,
+        target: Option<BasicBlockId>,
+        fn_range: Option<Range>,
     },
+    TailCall {
+        func: MirOperand,
+        args: Vec<MirOperand>,
+        fn_range: Option<Range>,
+    },
+    Assert {
+        cond: MirOperand,
+        target: BasicBlockId,
+    },
+    // TODO: UnwindResume, UnwindTerminate, Yield, CoroutineDrop, FalseEdge, FalseUnwind, InlineAsm
     Other {
-        range: Option<Range>,
         successors: Vec<BasicBlockId>,
     },
 }
 impl MirTerminator {
-    pub fn range(&self) -> Option<Range> {
-        match self {
-            Self::Drop { range, .. } => *range,
-            Self::Call { fn_span, .. } => *fn_span,
-            Self::Other { range, .. } => *range,
-        }
-    }
     pub fn successors(&self) -> Vec<BasicBlockId> {
-        match self {
-            Self::Drop { successors, .. } => successors.clone(),
-            Self::Call { successors, .. } => successors.clone(),
-            Self::Other { successors, .. } => successors.clone(),
+        match &self.kind {
+            MirTerminatorKind::Goto { target } => vec![*target],
+            MirTerminatorKind::SwitchInt { targets, .. } => targets.clone(),
+            MirTerminatorKind::Drop { target, .. } => vec![*target],
+            MirTerminatorKind::Call { target, .. } => (*target).into_iter().collect(),
+            MirTerminatorKind::Assert { target, .. } => vec![*target],
+            MirTerminatorKind::Other { successors } => successors.clone(),
+            MirTerminatorKind::TailCall { .. }
+            | MirTerminatorKind::Return
+            | MirTerminatorKind::Unreachable => Vec::new(),
         }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -318,7 +318,7 @@ pub struct BasicBlockId(pub usize);
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MirBasicBlock {
     pub statements: Vec<MirStatement>,
-    pub terminator: Option<MirTerminator>,
+    pub terminator: MirTerminator,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -197,16 +197,26 @@ impl Crate {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "snake_case", tag = "type")]
+pub enum MirOperand {
+    Copy { target_local: FnLocal, range: Range },
+    Move { target_local: FnLocal, range: Range },
+    Other,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case", tag = "type")]
 pub enum MirRval {
-    Move {
-        target_local: FnLocal,
-        range: Range,
+    Operand {
+        operand: MirOperand,
     },
     Borrow {
         target_local: FnLocal,
         range: Range,
         mutable: bool,
         outlive: Option<Range>,
+    },
+    Aggregate {
+        fields: Vec<Option<MirOperand>>,
     },
 }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -337,9 +337,12 @@ pub async fn setup_cargo_command() -> tokio::process::Command {
         .unwrap_or("".to_string());
 
     let sysroot = get_sysroot().await;
+    // use `RUSTOWLC` and `RUSTOWLC_WORKSPACE_WRAPPER` env var to configure `rustowlc` path
+    let rustowlc = env::var("RUSTOWLC").unwrap_or(rustowlc);
+    let rustowlc_workspace = env::var("RUSTOWLC_WORKSPACE_WRAPPER").unwrap_or(rustowlc.clone());
     command
         .env("RUSTC", &rustowlc)
-        .env("RUSTC_WORKSPACE_WRAPPER", &rustowlc)
+        .env("RUSTC_WORKSPACE_WRAPPER", &rustowlc_workspace)
         .env(
             "CARGO_ENCODED_RUSTFLAGS",
             format!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -120,9 +120,7 @@ pub fn mir_visit(func: &Function, visitor: &mut impl MirVisitor) {
         for stmt in &bb.statements {
             visitor.visit_stmt(stmt);
         }
-        if let Some(term) = &bb.terminator {
-            visitor.visit_term(term);
-        }
+        visitor.visit_term(&bb.terminator);
     }
 }
 

--- a/tests/snapshots/algorithm__f3_v2.snap
+++ b/tests/snapshots/algorithm__f3_v2.snap
@@ -16,9 +16,7 @@ expression: output
 [2m  24 |[0m     [96mprintln[0m[96m![0m[2m([0m[92m"{r:?}"[0m[2m)[0m[2m;[0m
 [2m     |[0m     [91m~~~~~~~~~~~~~~~~~[0m
 [2m  25 |[0m [2m}[0m
-[2m     |[0m [92m~[0m
 [2m  26 |[0m 
-[2m  27 |[0m [95mfn[0m f4[2m([0m[2m)[0m [2m{[0m
 
 [96mLegend:[0m
   [92m---[0m definitely live (lifetime)


### PR DESCRIPTION
## Type Of Change

<!-- What types of changes does your code introduce? Remove the options that do not apply. -->

- Bug fix
- Enhancement

## Description

Currently, some move/drop cannot be tracked (e.g. move to struct field).
So in this PR, support all MIR statements to track all move/drop events.

Note: Frontends (VS Code, Neovim, Emacs) use calculated ranges, so there is no need to support this change.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Read the [contribution guidelines](/docs/CONTRIBUTING.md)
- Ensure there isn't another pr solving the same problem.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the documentation (if applicable)
- Please include relevant tests that fail without this PR but pass with it.

Thanks for your contribution! We appreciate your help in making RustOwl better.
---------------------------------------------------------------------->
