### PR TITLE
fix(ci): release CI

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -1,0 +1,99 @@
+name: Make GitHub Draft / Docker image
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  check:
+    uses: ./.github/workflows/checks.yml
+  build:
+    uses: ./.github/workflows/build.yml
+
+  meta:
+    name: Check Version
+    runs-on: ubuntu-latest
+    outputs:
+      pre_release: ${{ steps.pre-release.outputs.pre_release }}
+    needs:
+      - check
+      - build
+    steps:
+      - name: Check pre-release
+        id: pre-release
+        run: |
+          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "pre_release=false" >> $GITHUB_OUTPUT
+          else
+            echo "pre_release=true" >> $GITHUB_OUTPUT
+          fi
+
+  github-release:
+    name: Create A GitHub Release
+    runs-on: ubuntu-latest
+    needs: ["meta"]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+      - name: Generate Release Notes
+        run: |
+          npx changelogithub@latest --contributors --output release.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          pattern: rustowl-*
+          merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: artifacts/**/*
+          draft: true
+          body_path: release.md
+          prerelease: ${{ needs.meta.outputs.pre_release == 'true' }}
+
+  docker-release:
+    name: Release To GitHub Container Registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/.github/workflows/release-registries.yml
+++ b/.github/workflows/release-registries.yml
@@ -1,54 +1,29 @@
-name: Release RustOwl
+name: Release to Registries
 
 on:
-  push:
-    tags:
-      - v*
+  release:
+    types:
+      - published
 
 permissions:
   actions: read
   contents: write
 
 jobs:
-  check:
-    uses: ./.github/workflows/checks.yml
-  build:
-    uses: ./.github/workflows/build.yml
-
-  meta:
-    name: Check Version
-    runs-on: ubuntu-latest
-    outputs:
-      pre_release: ${{ steps.pre-release.outputs.pre_release }}
-    needs:
-      - check
-      - build
-    steps:
-      - name: Check pre-release
-        id: pre-release
-        run: |
-          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "pre_release=false" >> $GITHUB_OUTPUT
-          else
-            echo "pre_release=true" >> $GITHUB_OUTPUT
-          fi
-
   crates-io-release:
     name: Create Crates.io release
     runs-on: ubuntu-latest
-    needs: ["meta"]
     steps:
       - uses: actions/checkout@v6
       - name: Release crates.io
-        if: needs.meta.outputs.pre_release != 'true'
         run: |
           echo '${{ secrets.CRATES_IO_API_TOKEN }}' | cargo login
           cargo publish
 
   vscode-release:
     name: Create Vscode Release
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
-    needs: ["meta"]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node.js
@@ -56,14 +31,12 @@ jobs:
         with:
           node-version: 22
       - name: Setup PNPM And Install dependencies
-        if: needs.meta.outputs.pre_release != 'true'
         uses: pnpm/action-setup@v6
         with:
           package_json_file: ./vscode/package.json
           run_install: |
             - cwd: ./vscode
       - name: Release vsce
-        if: needs.meta.outputs.pre_release != 'true'
         run: |
           pnpm vsce publish --no-dependencies
         working-directory: ./vscode
@@ -72,8 +45,8 @@ jobs:
 
   vscodium-release:
     name: Create Vscodium Release
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
-    needs: ["meta"]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node.js
@@ -81,14 +54,12 @@ jobs:
         with:
           node-version: 22
       - name: Setup PNPM And Install dependencies
-        if: needs.meta.outputs.pre_release != 'true'
         uses: pnpm/action-setup@v6
         with:
           package_json_file: ./vscode/package.json
           run_install: |
             - cwd: ./vscode
       - name: Release ovsx
-        if: needs.meta.outputs.pre_release != 'true'
         run: |
           pnpm ovsx publish --no-dependencies
         working-directory: ./vscode
@@ -97,25 +68,23 @@ jobs:
 
   winget-release:
     name: Create Winget Release
+    if: ${{ !github.event.release.prerelease }}
     runs-on: windows-latest
-    needs: ["meta"]
     steps:
       - uses: vedantmgoyal9/winget-releaser@main
-        if: needs.meta.outputs.pre_release != 'true'
         with:
           identifier: Cordx56.Rustowl
           token: ${{ secrets.WINGET_TOKEN }}
 
   aur-release:
     name: Create AUR Release
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
-    needs: ["meta"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
       - name: AUR Release
         uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
-        if: needs.meta.outputs.pre_release != 'true'
         with:
           pkgname: rustowl
           pkgbuild: ./aur/PKGBUILD
@@ -131,7 +100,6 @@ jobs:
           AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
       - name: AUR Release (Bin)
         uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
-        if: needs.meta.outputs.pre_release != 'true'
         with:
           pkgname: rustowl-bin
           pkgbuild: ./aur/PKGBUILD-BIN
@@ -145,69 +113,3 @@ jobs:
           AUR_USERNAME: ${{ secrets.AUR_USERNAME }}
           AUR_EMAIL: ${{ secrets.AUR_EMAIL }}
           AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-
-  github-release:
-    name: Create A GitHub Release
-    runs-on: ubuntu-latest
-    needs: ["meta"]
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-      - name: Generate Release Notes
-        run: |
-          npx changelogithub@latest --contributors --output release.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Download All Artifacts
-        uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-          pattern: rustowl-*
-          merge-multiple: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Release
-        uses: softprops/action-gh-release@v3
-        with:
-          files: artifacts/**/*
-          draft: true
-          body_path: release.md
-          prerelease: ${{ needs.meta.outputs.pre_release == 'true' }}
-
-  docker-release:
-    name: Release To GitHub Container Registry
-    runs-on: ubuntu-latest
-    needs: ["meta"]
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Release vsce
         if: needs.meta.outputs.pre_release != 'true'
         run: |
-          pnpm vsce publish
+          pnpm vsce publish --no-dependencies
         working-directory: ./vscode
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
@@ -90,7 +90,7 @@ jobs:
       - name: Release ovsx
         if: needs.meta.outputs.pre_release != 'true'
         run: |
-          pnpm ovsx publish
+          pnpm ovsx publish --no-dependencies
         working-directory: ./vscode
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "rustowl"
-version = "1.0.0-rc.1"
+version = "0.4.0"
 dependencies = [
  "anstyle",
  "cargo_metadata",

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,17 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY scripts/ scripts/
-RUN ./scripts/build/toolchain cargo install cargo-chef --locked
+RUN ./scripts/toolchain cargo install cargo-chef --locked
 
 FROM chef AS planner
 COPY . .
-RUN ./scripts/build/toolchain cargo chef prepare --recipe-path recipe.json
+RUN ./scripts/toolchain cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
-RUN ./scripts/build/toolchain cargo chef cook --release --recipe-path recipe.json
+RUN ./scripts/toolchain cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN ./scripts/build/toolchain cargo build --release
+RUN ./scripts/toolchain cargo build --release
 
 # final image
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Type Of Change

<!-- What types of changes does your code introduce? Remove the options that do not apply. -->

- Other (CI)

## Description

Some registry release scripts require that GitHub release is already published.
I would like to review GitHub release before it is published, so I split release CI into two parts: GitHub release draft and registry release.
Registry release will run when GitHub release is published.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Read the [contribution guidelines](/docs/CONTRIBUTING.md)
- Ensure there isn't another pr solving the same problem.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the documentation (if applicable)
- Please include relevant tests that fail without this PR but pass with it.

Thanks for your contribution! We appreciate your help in making RustOwl better.
---------------------------------------------------------------------->
