### PR TITLE
fix(rustowlc): use default borrowck results for return value

### DIFF
--- a/src/bin/core/mod.rs
+++ b/src/bin/core/mod.rs
@@ -43,6 +43,15 @@ static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
         .unwrap()
 });
 
+fn default_mir_borrowck(
+    tcx: TyCtxt<'_>,
+    def_id: LocalDefId,
+) -> queries::mir_borrowck::ProvidedValue<'_> {
+    let mut providers = rustc_middle::query::Providers::default();
+    rustc_borrowck::provide(&mut providers);
+    (providers.mir_borrowck)(tcx, def_id)
+}
+
 #[rustversion::since(1.94.0)]
 fn override_queries(_session: &rustc_session::Session, local: &mut Providers) {
     local.queries.mir_borrowck = mir_borrowck;
@@ -54,6 +63,7 @@ fn override_queries(_session: &rustc_session::Session, local: &mut Providers) {
 fn mir_borrowck(tcx: TyCtxt<'_>, def_id: LocalDefId) -> queries::mir_borrowck::ProvidedValue<'_> {
     log::debug!("start borrowck of {def_id:?}");
 
+    let result = default_mir_borrowck(tcx, def_id);
     let analyzers = MirAnalyzer::init(AsRustc::from_rustc(tcx), AsRustc::from_rustc(def_id));
     {
         let mut tasks = TASKS.lock().unwrap();
@@ -75,7 +85,7 @@ fn mir_borrowck(tcx: TyCtxt<'_>, def_id: LocalDefId) -> queries::mir_borrowck::P
         }
     }
 
-    Ok(tcx.arena.alloc(Default::default()))
+    result
 }
 
 pub struct AnalyzerCallback;

--- a/src/bin/core/mod.rs
+++ b/src/bin/core/mod.rs
@@ -43,14 +43,13 @@ static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
         .unwrap()
 });
 
-fn default_mir_borrowck(
-    tcx: TyCtxt<'_>,
-    def_id: LocalDefId,
-) -> queries::mir_borrowck::ProvidedValue<'_> {
+static DEFAULT_MIR_BORROWCK: LazyLock<
+    fn(TyCtxt<'_>, LocalDefId) -> queries::mir_borrowck::ProvidedValue<'_>,
+> = LazyLock::new(|| {
     let mut providers = rustc_middle::query::Providers::default();
     rustc_borrowck::provide(&mut providers);
-    (providers.mir_borrowck)(tcx, def_id)
-}
+    providers.mir_borrowck
+});
 
 #[rustversion::since(1.94.0)]
 fn override_queries(_session: &rustc_session::Session, local: &mut Providers) {
@@ -63,7 +62,7 @@ fn override_queries(_session: &rustc_session::Session, local: &mut Providers) {
 fn mir_borrowck(tcx: TyCtxt<'_>, def_id: LocalDefId) -> queries::mir_borrowck::ProvidedValue<'_> {
     log::debug!("start borrowck of {def_id:?}");
 
-    let result = default_mir_borrowck(tcx, def_id);
+    let default_borrowck_result = DEFAULT_MIR_BORROWCK(tcx, def_id);
     let analyzers = MirAnalyzer::init(AsRustc::from_rustc(tcx), AsRustc::from_rustc(def_id));
     {
         let mut tasks = TASKS.lock().unwrap();
@@ -85,7 +84,7 @@ fn mir_borrowck(tcx: TyCtxt<'_>, def_id: LocalDefId) -> queries::mir_borrowck::P
         }
     }
 
-    result
+    default_borrowck_result
 }
 
 pub struct AnalyzerCallback;


### PR DESCRIPTION
## Type Of Change

<!-- What types of changes does your code introduce? Remove the options that do not apply. -->

- Bug fix

## Description

Some crates (I found it in proprietary crates) failed to analyze due to empty borrowck results.
To fix this, try borrowck first and return its result value.

This cause analysis slowdown (about x1.5 analysis time), but I don't know other fix.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Read the [contribution guidelines](/docs/CONTRIBUTING.md)
- Ensure there isn't another pr solving the same problem.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the documentation (if applicable)
- Please include relevant tests that fail without this PR but pass with it.

Thanks for your contribution! We appreciate your help in making RustOwl better.
---------------------------------------------------------------------->
