### PR TITLE
fix: rustowl toolchain install fails for nightly toolchain (404 downloading rust-std/cargo)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -68,11 +68,19 @@ fn get_toolchain() -> String {
     }
 }
 fn get_channel() -> String {
-    get_toolchain()
-        .split("-")
-        .next()
-        .expect("failed to obtain channel from toolchain")
-        .to_owned()
+    let toolchain = get_toolchain();
+
+    if toolchain.contains("-nightly-") {
+        "nightly".to_string()
+    } else if toolchain.contains("-beta") {
+        "beta".to_string()
+    } else {
+        toolchain
+            .split('-')
+            .next()
+            .expect("failed to obtain channel from toolchain")
+            .to_owned()
+    }
 }
 fn get_toolchain_date() -> Option<String> {
     let r = regex::Regex::new(r#"\d\d\d\d-\d\d-\d\d"#).unwrap();


### PR DESCRIPTION
…g rust-std/cargo) #668

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Type Of Change

<!-- What types of changes does your code introduce? Remove the options that do not apply. -->

- Bug fix
- New feature
- Documentation update
- Enhancement
- Breaking change
- Other

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Read the [contribution guidelines](/docs/CONTRIBUTING.md)
- Ensure there isn't another pr solving the same problem.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the documentation (if applicable)
- Please include relevant tests that fail without this PR but pass with it.

Thanks for your contribution! We appreciate your help in making RustOwl better.
---------------------------------------------------------------------->
